### PR TITLE
Make Update-ZoomUser handle first name parameter correctly

### DIFF
--- a/PSZoom/Public/Users/Update-ZoomUser.ps1
+++ b/PSZoom/Public/Users/Update-ZoomUser.ps1
@@ -172,6 +172,7 @@ function Update-ZoomUser {
             }
 
             $KeyValuePairs = @{
+                'first_name'  = $FirstName
                 'last_name'   = $LastName
                 'timezone'    = $Timezone
                 'language'    = $Language


### PR DESCRIPTION
The current implementation of `Update-ZoomUser` is missing the `first_name` parameter in the request. This adds it to the key-value pairs list