### PR TITLE
Initial Commit - Get-ZoomGroupMembers

### DIFF
--- a/PSZoom/Public/Groups/Get-ZoomGroupMembers.ps1
+++ b/PSZoom/Public/Groups/Get-ZoomGroupMembers.ps1
@@ -1,0 +1,89 @@
+<#
+
+.SYNOPSIS
+Get members for a group.
+
+.DESCRIPTION
+Get members for a group.
+Prerequisite: Pro, Business, or Education account
+
+.PARAMETER GroupId
+The ID of the group as returned from "Get-ZoomGroups".
+
+.PARAMETER PageSize
+The number of records returned within a single API call. Default value is 30. Maximum value is 300.
+
+.PARAMETER NextPageToken
+Token to return next page of results when greater than PageSize as returned from this function.
+(Zoom is depricating use of PageNumber so not going to implement that.)
+
+.PARAMETER ApiKey
+The Api Key.
+
+.PARAMETER ApiSecret
+The Api Secret.
+
+.OUTPUTS
+Zoom response as an object.
+
+.LINK
+https://marketplace.zoom.us/docs/api-reference/zoom-api/groups/groupmembers
+
+.EXAMPLE
+Return first 30 members of Group.
+Get-ZoomGroupMembers -GroupId 24e50639b5bb4fab9c3c
+
+.EXAMPLE
+Return first 100 members of Group.
+Get-ZoomGroupMembers -GroupId 24e50639b5bb4fab9c3c -PageSize 100
+
+.EXAMPLE
+Return the 50 members of Group from the specipide page of results.
+Get-ZoomGroupMembers -GroupId 24e50639b5bb4fab9c3c -PageSize 50 -NextPageToken kwJNZhamVutyOKA7TZYmIWKbgkacbfU0UU2
+
+#>
+
+function Get-ZoomGroupMembers  {
+    param (
+        [Parameter(
+            Mandatory = $True, 
+            ValueFromPipelineByPropertyName = $True, 
+            Position = 0
+        )]
+        [Alias('group_id', 'group', 'id')]
+        [string]$GroupId,
+
+        [string]$ApiKey,
+        
+        [string]$ApiSecret,
+
+        [ValidateRange(1, 300)]
+        [Alias('page_size')]
+        [int]$PageSize = 30,
+
+        [Alias('next_page_token')]
+        [String]$NextPageToken = ""
+    )
+
+    begin {
+        #Generate Headers and JWT (JSON Web Token)
+        $Headers = New-ZoomHeaders -ApiKey $ApiKey -ApiSecret $ApiSecret
+    }
+
+    process {
+        $Request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$GroupId/members"
+        $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+        $query.Add('page_size', $PageSize)
+        $query.Add('next_page_token', $NextPageToken)
+
+        $Request.Query = $query.ToString()
+
+        try {
+            $response = Invoke-RestMethod -Uri $request.Uri -Headers $headers -Method GET
+        } catch {
+            Write-Error -Message "$($_.Exception.Message)" -ErrorId $_.Exception.Code -Category InvalidOperation
+        } finally {
+            Write-Output $response
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Remove-ZoomMeetingRecordings
 Add-ZoomGroupMember  
 Get-ZoomGroup  
 Get-ZoomGroupLockSettings  
+Get-ZoomGroupMembers  
 Get-ZoomGroups  
 Get-ZoomGroupSettings  
 New-ZoomGroup  


### PR DESCRIPTION
Added a function to pull all members of a specified group.  I used the existing "Get-ZoomGroup" function code and extended it to support the additional functionality I was after.   As Zoom is deprecating the use of "page_number" in the API I implemented the new "next_page_token" instead.