### PR TITLE
Add token refresh logic to Invoke-ZoomRestMethod

### DIFF
--- a/PSZoom/Private/Invoke-ZoomRestMethod.ps1
+++ b/PSZoom/Private/Invoke-ZoomRestMethod.ps1
@@ -118,7 +118,7 @@ function Invoke-ZoomRestMethod {
         # Update the token if it has expired.
         $TokenPayload = ($Headers.Value.authorization -split '\.')[1]
         $TokenExpireTime = [int]((ConvertFrom-Json ([System.Text.Encoding]::UTF8.GetString(
-                        [Convert]::FromBase64String($TokenPayload + '=' * (4 - $TokenPayload.Length % 4))))).exp)
+                        [Convert]::FromBase64String($TokenPayload + '=' * @(0..3)[ - ($TokenPayload.Length % 4)])))).exp)
         $CurrentUnixTime = ((Get-Date) - (Get-Date '1970/1/1 0:0:0 GMT')).TotalSeconds
         if ($CurrentUnixTime -ge $TokenExpireTime) {
             $Headers.Value = New-ZoomHeaders -ApiKey $ApiKey -ApiSecret $ApiSecret

--- a/PSZoom/Private/Invoke-ZoomRestMethod.ps1
+++ b/PSZoom/Private/Invoke-ZoomRestMethod.ps1
@@ -136,7 +136,8 @@ function Invoke-ZoomRestMethod {
     }
     catch {
         if ($PSVersionTable.PSVersion.Major -lt 6) {
-            $errorDetails = ConvertFrom-Json $_.errorDetails
+            $errorStreamReader = [System.IO.StreamReader]::new($_.exception.Response.GetResponseStream())
+            $errorDetails = ConvertFrom-Json ($errorStreamReader.ReadToEnd())
         }
         else {
             $errorDetails = ConvertFrom-Json $_.errorDetails -AsHashtable

--- a/PSZoom/Private/Invoke-ZoomRestMethod.ps1
+++ b/PSZoom/Private/Invoke-ZoomRestMethod.ps1
@@ -8,7 +8,7 @@
 function Invoke-ZoomRestMethod {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     param (
-        $Method,
+        [Microsoft.PowerShell.Commands.WebRequestMethod]$Method,
         [switch]$FollowRelLink,
         [int]$MaximumFollowRelLink,
         [string]$ResponseHeadersVariable,
@@ -159,11 +159,14 @@ function Invoke-ZoomRestMethod {
             -CategoryActivity $targetObject.method -Category $category
 
         #Rate limiting logic
-
         if ($errorCode -eq 429) {
-            Write-Warning 'Error 429. Too many requests encountered. This is usually because of rate limiting. Retrying in 1 second.'
-            Start-Sleep -Seconds 1
-            Invoke-ZoomRestMethod @params
+            # Max retry count: 5
+            if ($script:RetryCount -lt 5) {
+                $script:RetryCount++
+                Write-Warning 'Error 429. Too many requests encountered. This is usually because of rate limiting. Retrying in 1 second.'
+                Start-Sleep -Seconds 1
+                Invoke-ZoomRestMethod @params
+            }
         }
     }
     

--- a/PSZoom/Public/CloudRecording/Get-ZoomAccountRecordings.ps1
+++ b/PSZoom/Public/CloudRecording/Get-ZoomAccountRecordings.ps1
@@ -105,7 +105,7 @@ function Get-ZoomAccountRecordings {
         } 
         
         $Request.Query = $query.ToString()
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $Headers -Body $RequestBody -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
         Write-Output $response
     }

--- a/PSZoom/Public/CloudRecording/Get-ZoomMeetingRecordings.ps1
+++ b/PSZoom/Public/CloudRecording/Get-ZoomMeetingRecordings.ps1
@@ -51,7 +51,7 @@ function Get-ZoomMeetingRecordings {
     process {
         $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/recordings"
 
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $Headers -Body $RequestBody -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
         Write-Output $response
     }

--- a/PSZoom/Public/CloudRecording/Get-ZoomRecordings.ps1
+++ b/PSZoom/Public/CloudRecording/Get-ZoomRecordings.ps1
@@ -136,7 +136,7 @@ function Get-ZoomRecordings {
             
             $Request.Query = $query.ToString()
 
-            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $Headers -Body $RequestBody -Method GET
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
     
             Write-Output $response
         }

--- a/PSZoom/Public/CloudRecording/Remove-ZoomMeetingRecordingFile.ps1
+++ b/PSZoom/Public/CloudRecording/Remove-ZoomMeetingRecordingFile.ps1
@@ -73,7 +73,7 @@ function Remove-ZoomMeetingRecordingFile {
             $Request.Query = $query.ToString()
 
             if ($PScmdlet.ShouldProcess($user, 'Remove')) {
-                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $Headers -Body $RequestBody -Method DELETE
+                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method DELETE -ApiKey $ApiKey -ApiSecret $ApiSecret
 
                 Write-Output $response
             }

--- a/PSZoom/Public/CloudRecording/Remove-ZoomMeetingRecordings.ps1
+++ b/PSZoom/Public/CloudRecording/Remove-ZoomMeetingRecordings.ps1
@@ -67,7 +67,7 @@ function Remove-ZoomMeetingRecordings {
             $Request.Query = $query.ToString()
 
             if ($PScmdlet.ShouldProcess($user, 'Remove')) {
-                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $Headers -Body $RequestBody -Method DELETE
+                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method DELETE -ApiKey $ApiKey -ApiSecret $ApiSecret
 
                 Write-Output $response
             }

--- a/PSZoom/Public/Groups/Add-ZoomGroupMember.ps1
+++ b/PSZoom/Public/Groups/Add-ZoomGroupMember.ps1
@@ -122,7 +122,7 @@ function Add-ZoomGroupMember  {
         foreach ($Id in $GroupId) {
             $request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$Id/members"
             if ($PScmdlet.ShouldProcess($members, 'Add')) {
-                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $RequestBody -Method POST
+                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method POST -ApiKey $ApiKey -ApiSecret $ApiSecret
 
                 if (-not $passthru) {
                     Write-Output $response

--- a/PSZoom/Public/Groups/Get-ZoomGroup.ps1
+++ b/PSZoom/Public/Groups/Get-ZoomGroup.ps1
@@ -41,7 +41,7 @@ function Get-ZoomGroup  {
     process {
         $Request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$GroupId"
 
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
         
         Write-Output $response

--- a/PSZoom/Public/Groups/Get-ZoomGroupLockSettings.ps1
+++ b/PSZoom/Public/Groups/Get-ZoomGroupLockSettings.ps1
@@ -52,7 +52,7 @@ function Get-ZoomGroupLockSettings  {
     process {
         $Request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$GroupId/lock_settings"
 
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
 
         Write-Output $response   

--- a/PSZoom/Public/Groups/Get-ZoomGroupMembers.ps1
+++ b/PSZoom/Public/Groups/Get-ZoomGroupMembers.ps1
@@ -76,7 +76,7 @@ function Get-ZoomGroupMembers  {
         $query.Add('page_size', $PageSize)
         $query.Add('next_page_token', $NextPageToken)
         $request.Query = $query.ToString()
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
         Write-Output $response
     }

--- a/PSZoom/Public/Groups/Get-ZoomGroupSettings.ps1
+++ b/PSZoom/Public/Groups/Get-ZoomGroupSettings.ps1
@@ -52,7 +52,7 @@ function Get-ZoomGroupSettings  {
     process {
         $Request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$GroupId/settings"
 
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
 
         Write-Output $response   

--- a/PSZoom/Public/Groups/Get-ZoomGroups.ps1
+++ b/PSZoom/Public/Groups/Get-ZoomGroups.ps1
@@ -62,7 +62,7 @@ function Get-ZoomGroups  {
     process {
         $Request = [System.UriBuilder]"https://api.zoom.us/v2/groups"
 
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
 
         if ($FullApiResponse) {

--- a/PSZoom/Public/Groups/New-ZoomGroup.ps1
+++ b/PSZoom/Public/Groups/New-ZoomGroup.ps1
@@ -60,7 +60,7 @@ function New-ZoomGroup {
 
                 $requestBody = $requestBody | ConvertTo-Json
 
-                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $requestBody -Method POST
+                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method POST -ApiKey $ApiKey -ApiSecret $ApiSecret
 
                 Write-Verbose "Creating group $n."
                 Write-Output $response

--- a/PSZoom/Public/Groups/Remove-ZoomGroup.ps1
+++ b/PSZoom/Public/Groups/Remove-ZoomGroup.ps1
@@ -52,7 +52,7 @@ function Remove-ZoomGroup {
             #Need to add API rate limiting
             $Request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$Id"
             if ($PSCmdlet.ShouldProcess($Id, "Remove")) {
-                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method DELETE
+                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method DELETE -ApiKey $ApiKey -ApiSecret $ApiSecret
                 Write-Verbose "Group $Id deleted."
                 Write-Output $response
             }

--- a/PSZoom/Public/Groups/Remove-ZoomGroupMembers.ps1
+++ b/PSZoom/Public/Groups/Remove-ZoomGroupMembers.ps1
@@ -63,7 +63,7 @@ function Remove-ZoomGroupMembers {
                 
                 if ($PScmdlet.ShouldProcess) {
                     Write-Verbose "Removing $MemberId from $GroupId."
-                    $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method DELETE
+                    $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method DELETE -ApiKey $ApiKey -ApiSecret $ApiSecret
 
                     Write-Output $response
                 }

--- a/PSZoom/Public/Groups/Update-ZoomGroup.ps1
+++ b/PSZoom/Public/Groups/Update-ZoomGroup.ps1
@@ -69,7 +69,7 @@ function Update-ZoomGroup  {
         $requestBody = $requestBody | ConvertTo-Json
 
         if ($PScmdlet.ShouldProcess($GroupId, 'Update')) {
-            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $requestBody -Method PATCH
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $requestBody -Method PATCH -ApiKey $ApiKey -ApiSecret $ApiSecret
 
             Write-Verbose "Changed group name to $Name."
             Write-Output $response

--- a/PSZoom/Public/Groups/Update-ZoomGroupLockSettings.ps1
+++ b/PSZoom/Public/Groups/Update-ZoomGroupLockSettings.ps1
@@ -581,7 +581,7 @@ function Update-ZoomGroupLockSettings  {
 
             $request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$GroupId/lock_settings"
 
-            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $requestBody -Method PATCH
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $requestBody -Method PATCH -ApiKey $ApiKey -ApiSecret $ApiSecret
 
             if (-not $Passthru) {
                 Write-Output $response

--- a/PSZoom/Public/Groups/Update-ZoomGroupSettings.ps1
+++ b/PSZoom/Public/Groups/Update-ZoomGroupSettings.ps1
@@ -578,7 +578,7 @@ function Update-ZoomGroupSettings  {
 
             $request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$GroupId/settings"
 
-            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $requestBody -Method PATCH
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $requestBody -Method PATCH -ApiKey $ApiKey -ApiSecret $ApiSecret
 
             if (-not $Passthru) {
                 Write-Output $response

--- a/PSZoom/Public/Meetings/Add-ZoomMeetingRegistrant.ps1
+++ b/PSZoom/Public/Meetings/Add-ZoomMeetingRegistrant.ps1
@@ -222,7 +222,7 @@ function Add-ZoomMeetingRegistrant {
         }
 
         $requestBody = $requestBody | ConvertTo-Json
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $requestBody -Method POST
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method POST -ApiKey $ApiKey -ApiSecret $ApiSecret
 
         Write-Output $response
    

--- a/PSZoom/Public/Meetings/Get-ZoomEndedMeetingInstances.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomEndedMeetingInstances.ps1
@@ -44,7 +44,7 @@ function Get-ZoomEndedMeetingInstances {
 
     process {
         $Request = [System.UriBuilder]"https://api.zoom.us/v2/past_meetings/$MeetingId/instances"
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $RequestBody -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
         
         Write-Output $response
     }

--- a/PSZoom/Public/Meetings/Get-ZoomMeeting.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomMeeting.ps1
@@ -71,7 +71,7 @@ function Get-ZoomMeeting {
             $query.Add('occurrence_id', $OccurrenceId)
             $Request.Query = $query.toString()
         }        
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $RequestBody -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
         
         Write-Output $response
     }

--- a/PSZoom/Public/Meetings/Get-ZoomMeetingInvitation.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomMeetingInvitation.ps1
@@ -44,7 +44,7 @@ function Get-ZoomMeetingInvitation {
     process {
         $Uri = "https://api.zoom.us/v2/meetings/$MeetingId/invitation"
         
-        $response = Invoke-ZoomRestMethod -Uri $Uri -Headers $headers -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $Uri -Headers ([ref]$headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
         
         Write-Output $response
     }

--- a/PSZoom/Public/Meetings/Get-ZoomMeetingPoll.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomMeetingPoll.ps1
@@ -55,7 +55,7 @@ function Get-ZoomMeetingPoll {
     process {
         $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/polls/$PollId"
     
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $RequestBody -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
         
         Write-Output $response
     }

--- a/PSZoom/Public/Meetings/Get-ZoomMeetingPolls.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomMeetingPolls.ps1
@@ -47,7 +47,7 @@ function Get-ZoomMeetingPolls {
     process {
         $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/polls"
    
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $RequestBody -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
         
         Write-Output $response
     }

--- a/PSZoom/Public/Meetings/Get-ZoomMeetingRegistrants.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomMeetingRegistrants.ps1
@@ -73,7 +73,7 @@ function Get-ZoomMeetingRegistrants {
 
         $request.Query = $query.ToString()
         
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
         
         Write-Output $response

--- a/PSZoom/Public/Meetings/Get-ZoomMeetingsFromUser.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomMeetingsFromUser.ps1
@@ -76,7 +76,7 @@ function Get-ZoomMeetingsFromUser {
             $query.add('page_number', $PageNumber)
             $request.Query = $query.ToString()
         
-           $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+           $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
             
             Write-Output $response
         }

--- a/PSZoom/Public/Meetings/Get-ZoomPastMeetingDetails.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomPastMeetingDetails.ps1
@@ -45,7 +45,7 @@ function Get-ZoomPastMeetingDetails {
     process {
         $Uri = "https://api.zoom.us/v2/past_meetings/$MeetingUuid"
         
-        $response = Invoke-ZoomRestMethod -Uri $Uri -Headers $headers -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $Uri -Headers ([ref]$headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
         
         Write-Output $response
     }

--- a/PSZoom/Public/Meetings/Get-ZoomPastMeetingParticipants.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomPastMeetingParticipants.ps1
@@ -61,7 +61,7 @@ function Get-ZoomPastMeetingParticipants {
 
         $Request.Query = $query.ToString()
         
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $RequestBody -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
         
         Write-Output $response
     }

--- a/PSZoom/Public/Meetings/Get-ZoomRegistrationQuestions.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomRegistrationQuestions.ps1
@@ -45,7 +45,7 @@ function Get-ZoomRegistrationQuestions {
     process {
         $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/registrants/questions"
     
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $RequestBody -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
         
         Write-Output $response
     }

--- a/PSZoom/Public/Meetings/New-ZoomMeeting.ps1
+++ b/PSZoom/Public/Meetings/New-ZoomMeeting.ps1
@@ -839,7 +839,7 @@ function New-ZoomMeeting {
         #### Misc Settings End #####
 
         $requestBody = ConvertTo-Json $requestBody -Depth 10
-        $response = Invoke-ZoomRestMethod -Uri $Uri -Headers $Headers -Body $requestBody -Method Post
+        $response = Invoke-ZoomRestMethod -Uri $Uri -Headers ([ref]$Headers) -Body $requestBody -Method Post -ApiKey $ApiKey -ApiSecret $ApiSecret
 
         Write-Output $response
     }

--- a/PSZoom/Public/Meetings/New-ZoomMeetingPoll.ps1
+++ b/PSZoom/Public/Meetings/New-ZoomMeetingPoll.ps1
@@ -82,7 +82,7 @@ function New-ZoomMeetingPoll {
             $RequestBody.Add('questions', $Questions)
         }
 
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $RequestBody -Method POST
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method POST -ApiKey $ApiKey -ApiSecret $ApiSecret
 
         Write-Output $response
     }

--- a/PSZoom/Public/Meetings/Remove-ZoomMeeting.ps1
+++ b/PSZoom/Public/Meetings/Remove-ZoomMeeting.ps1
@@ -74,7 +74,7 @@ function Remove-ZoomMeeting {
             $Request.Query = $query.ToString()
         }
 
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method DELETE
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method DELETE -ApiKey $ApiKey -ApiSecret $ApiSecret
 
         if (-not $Passthru) {
             Write-Output $response

--- a/PSZoom/Public/Meetings/Remove-ZoomMeetingPoll.ps1
+++ b/PSZoom/Public/Meetings/Remove-ZoomMeetingPoll.ps1
@@ -53,7 +53,7 @@ function Remove-ZoomMeetingPoll {
 
     process {
         $request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/polls/$PollId"
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $RequestBody -Method DELETE
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method DELETE -ApiKey $ApiKey -ApiSecret $ApiSecret
         
         Write-Output $response
     }

--- a/PSZoom/Public/Meetings/Update-ZoomMeeting.ps1
+++ b/PSZoom/Public/Meetings/Update-ZoomMeeting.ps1
@@ -543,7 +543,7 @@ function Update-ZoomMeeting {
     }
 
     $requestBody = ConvertTo-Json $requestBody -Depth 10
-    $response = Invoke-ZoomRestMethod -Uri $Request.Uri -Headers $Headers -Body $requestBody -Method Patch
+    $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $requestBody -Method PATCH -ApiKey $ApiKey -ApiSecret $ApiSecret
 
     Write-Output $response
   }

--- a/PSZoom/Public/Meetings/Update-ZoomMeetingLiveStream.ps1
+++ b/PSZoom/Public/Meetings/Update-ZoomMeetingLiveStream.ps1
@@ -75,7 +75,7 @@ function Update-ZoomMeetingLiveStream {
 
         $requestBody = ConvertTo-Json $requestBody
                 
-        $response = Invoke-ZoomRestMethod -Uri $uri -Headers $headers -Body $requestBody -Method PATCH
+        $response = Invoke-ZoomRestMethod -Uri $uri -Headers ([ref]$Headers) -Body $requestBody -Method PATCH -ApiKey $ApiKey -ApiSecret $ApiSecret
         
         Write-Output $response
     }

--- a/PSZoom/Public/Meetings/Update-ZoomMeetingLiveStreamStatus.ps1
+++ b/PSZoom/Public/Meetings/Update-ZoomMeetingLiveStreamStatus.ps1
@@ -75,7 +75,7 @@ function Update-ZoomMeetingLiveStreamStatus {
         
         $requestBody = $requestBody | ConvertTo-Json
 
-        $response = Invoke-ZoomRestMethod -Uri $uri -Headers $headers -Body $requestBody -Method PATCH
+        $response = Invoke-ZoomRestMethod -Uri $uri -Headers ([ref]$Headers) -Body $requestBody -Method PATCH -ApiKey $ApiKey -ApiSecret $ApiSecret
         
         Write-Output $response
     }

--- a/PSZoom/Public/Meetings/Update-ZoomMeetingPoll.ps1
+++ b/PSZoom/Public/Meetings/Update-ZoomMeetingPoll.ps1
@@ -93,7 +93,7 @@ function Update-ZoomMeetingPoll {
 
         $requestBody = ConvertTo-Json $requestBody -Depth 10 #Uses -Depth because the questions.answers array is flattened without it.
 
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $requestBody -Method PUT
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $requestBody -Method PUT -ApiKey $ApiKey -ApiSecret $ApiSecret
 
         Write-Output $response
     }

--- a/PSZoom/Public/Meetings/Update-ZoomMeetingRegistrantStatus.ps1
+++ b/PSZoom/Public/Meetings/Update-ZoomMeetingRegistrantStatus.ps1
@@ -82,7 +82,7 @@ function Update-ZoomMeetingRegistrantStatus {
 
         $requestBody = $requestBody | ConvertTo-Json
 
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $requestBody -Method PUT
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $requestBody -Method PUT -ApiKey $ApiKey -ApiSecret $ApiSecret
         
         Write-Output $response
     }

--- a/PSZoom/Public/Meetings/Update-ZoomMeetingRegistrationQuestions.ps1
+++ b/PSZoom/Public/Meetings/Update-ZoomMeetingRegistrationQuestions.ps1
@@ -99,7 +99,7 @@ function Update-ZoomMeetingRegistrationQuestions {
         }
         
         $requestBody = $requestBody | ConvertTo-Json
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $requestBody -Method PATCH
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $requestBody -Method PATCH -ApiKey $ApiKey -ApiSecret $ApiSecret
 
         Write-Output $response
     }

--- a/PSZoom/Public/Meetings/Update-ZoomMeetingStatus.ps1
+++ b/PSZoom/Public/Meetings/Update-ZoomMeetingStatus.ps1
@@ -60,7 +60,7 @@ function Update-ZoomMeetingStatus {
 
         $requestBody = $requestBody | ConvertTo-Json
 
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $requestBody -Method PUT
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $requestBody -Method PUT -ApiKey $ApiKey -ApiSecret $ApiSecret
         
         Write-Output $response
     }

--- a/PSZoom/Public/Reports/Get-ZoomActiveInactiveHostReports.ps1
+++ b/PSZoom/Public/Reports/Get-ZoomActiveInactiveHostReports.ps1
@@ -150,7 +150,7 @@ function Get-ZoomActiveInactiveHostReports {
 
             $Request.Query = $query.ToString()
 
-            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
             
             Write-Output $response
         }

--- a/PSZoom/Public/Reports/Get-ZoomDailyUsageReport.ps1
+++ b/PSZoom/Public/Reports/Get-ZoomDailyUsageReport.ps1
@@ -71,7 +71,7 @@ function Get-ZoomDailyUsageReport {
             $Request.Query = $query.ToString()
         }
         
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
             
         Write-Output $response
     }

--- a/PSZoom/Public/Reports/Get-ZoomMeetingParticipantsReport.ps1
+++ b/PSZoom/Public/Reports/Get-ZoomMeetingParticipantsReport.ps1
@@ -91,7 +91,7 @@ function Get-ZoomMeetingParticipantsReport {
                 $query.Add('next_page_token', $NextPageToken)
                 $Request.Query = $query.ToString()
 
-                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
                 
                 Write-Output $response
             }

--- a/PSZoom/Public/Reports/Get-ZoomTelephoneReports.ps1
+++ b/PSZoom/Public/Reports/Get-ZoomTelephoneReports.ps1
@@ -139,7 +139,7 @@ function Get-ZoomTelephoneReports {
             $query.Add('page_number', $PageNumber)
             $Request.Query = $query.ToString()
 
-            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
             
             Write-Output $response
         }

--- a/PSZoom/Public/Reports/Get-ZoomWebinarDetailsReport.ps1
+++ b/PSZoom/Public/Reports/Get-ZoomWebinarDetailsReport.ps1
@@ -49,7 +49,7 @@ function Get-ZoomWebinarDetailsReport {
         foreach ($id in $WebinarId) {
             $Request = [System.UriBuilder]"https://api.zoom.us/v2/report/webinars/$WebinarId"
 
-            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
             
             Write-Output $response
         }

--- a/PSZoom/Public/Reports/Get-ZoomWebinarParticipantsReport.ps1
+++ b/PSZoom/Public/Reports/Get-ZoomWebinarParticipantsReport.ps1
@@ -73,7 +73,7 @@ function Get-ZoomWebinarParticipantsReport {
 
             $Request.Query = $query.ToString()
 
-            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
             
             Write-Output $response
         }

--- a/PSZoom/Public/Rooms/Connect-ZoomRoomMeeting.ps1
+++ b/PSZoom/Public/Rooms/Connect-ZoomRoomMeeting.ps1
@@ -139,7 +139,7 @@ function Connect-ZoomRoomMeeting {
             }
             
             $requestBody = ConvertTo-Json $requestBody -Depth 2
-            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $requestBody -Method POST
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method POST -ApiKey $ApiKey -ApiSecret $ApiSecret
 
             Write-Output $response
         }

--- a/PSZoom/Public/Rooms/Disconnect-ZoomRoomMeeting.ps1
+++ b/PSZoom/Public/Rooms/Disconnect-ZoomRoomMeeting.ps1
@@ -80,7 +80,7 @@ function Disconnect-ZoomRoomMeeting {
             }
             
             $requestBody = ConvertTo-Json $requestBody -Depth 2
-            $response = Invoke-ZoomRestMethod -Uri $Request.Uri -Headers $headers -Body $requestBody -Method POST
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method POST -ApiKey $ApiKey -ApiSecret $ApiSecret
     
             Write-Output $response
         }

--- a/PSZoom/Public/Rooms/Get-ZoomRoomLocations.ps1
+++ b/PSZoom/Public/Rooms/Get-ZoomRoomLocations.ps1
@@ -98,7 +98,7 @@ function Get-ZoomRoomLocations {
 
         $Request.Query = $query.ToString()
 
-        $response = Invoke-ZoomRestMethod -Uri $Request.Uri -Headers $headers -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
         if ($Full) {
             Write-Output $response

--- a/PSZoom/Public/Rooms/Get-ZoomRooms.ps1
+++ b/PSZoom/Public/Rooms/Get-ZoomRooms.ps1
@@ -147,7 +147,7 @@ function Get-ZoomRooms {
         $Request.Query = $query.ToString()
         
 
-        $response = Invoke-ZoomRestMethod -Uri $Request.Uri -Headers $headers -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
         if ($Full) {
             Write-Output $response

--- a/PSZoom/Public/Rooms/New-ZoomRoomInvite.ps1
+++ b/PSZoom/Public/Rooms/New-ZoomRoomInvite.ps1
@@ -97,7 +97,7 @@ function New-ZoomRoomInvite {
         }
         
         $requestBody = ConvertTo-Json $requestBody -Depth 2
-        $response = Invoke-ZoomRestMethod -Uri $Request.Uri -Headers $headers -Body $requestBody -Method POST
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method POST -ApiKey $ApiKey -ApiSecret $ApiSecret
 
         Write-Output $response
     }

--- a/PSZoom/Public/Rooms/New-ZoomRoomMeeting.ps1
+++ b/PSZoom/Public/Rooms/New-ZoomRoomMeeting.ps1
@@ -158,7 +158,7 @@ function New-ZoomRoomMeeting {
             }
             
             $requestBody = ConvertTo-Json $requestBody -Depth 2
-            $response = Invoke-ZoomRestMethod -Uri $Request.Uri -Headers $headers -Body $requestBody -Method POST
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method POST -ApiKey $ApiKey -ApiSecret $ApiSecret
 
             Write-Output $response
         }

--- a/PSZoom/Public/Rooms/Remove-ZoomRoomMeeting.ps1
+++ b/PSZoom/Public/Rooms/Remove-ZoomRoomMeeting.ps1
@@ -154,7 +154,7 @@ function Remove-ZoomRoomMeeting {
             }
             
             $requestBody = ConvertTo-Json $requestBody -Depth 2
-            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $requestBody -Method POST
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method POST -ApiKey $ApiKey -ApiSecret $ApiSecret
 
             Write-Output $response
         }

--- a/PSZoom/Public/Rooms/Restart-ZoomRoom.ps1
+++ b/PSZoom/Public/Rooms/Restart-ZoomRoom.ps1
@@ -82,7 +82,7 @@ function Restart-ZoomRoom {
             }
             
             $requestBody = ConvertTo-Json $requestBody -Depth 2
-            $response = Invoke-ZoomRestMethod -Uri $Request.Uri -Headers $headers -Body $requestBody -Method POST
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method POST -ApiKey $ApiKey -ApiSecret $ApiSecret
     
             Write-Output $response
         }

--- a/PSZoom/Public/Rooms/Stop-ZoomRoomMeeting.ps1
+++ b/PSZoom/Public/Rooms/Stop-ZoomRoomMeeting.ps1
@@ -80,7 +80,7 @@ function Stop-ZoomRoomMeeting {
             }
             
             $requestBody = ConvertTo-Json $requestBody -Depth 2
-            $response = Invoke-ZoomRestMethod -Uri $Request.Uri -Headers $headers -Body $requestBody -Method POST
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method POST -ApiKey $ApiKey -ApiSecret $ApiSecret
             
             Write-Output $response
         }

--- a/PSZoom/Public/Users/Add-ZoomUserAssistants.ps1
+++ b/PSZoom/Public/Users/Add-ZoomUserAssistants.ps1
@@ -94,7 +94,7 @@ function Add-ZoomUserAssistants {
             }
             
             $requestBody = $requestBody | ConvertTo-Json
-            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $requestBody -Method POST
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method POST -ApiKey $ApiKey -ApiSecret $ApiSecret
 
             
             if ($Passthru) {

--- a/PSZoom/Public/Users/Get-ZoomPersonalMeetingRoomName.ps1
+++ b/PSZoom/Public/Users/Get-ZoomPersonalMeetingRoomName.ps1
@@ -60,7 +60,7 @@ function Get-ZoomPersonalMeetingRoomName {
             $Request.Query = $query.ToString()
         
     
-           $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+           $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
     
             Write-Output $response
         }

--- a/PSZoom/Public/Users/Get-ZoomUser.ps1
+++ b/PSZoom/Public/Users/Get-ZoomUser.ps1
@@ -77,9 +77,9 @@ function Get-ZoomUser {
                 $query.Add('login_type', $LoginType)
                 $Request.Query = $query.ToString()
             }
-        
-            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
-            
+
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
+
             Write-Output $response
         }
     }

--- a/PSZoom/Public/Users/Get-ZoomUserAssistants.ps1
+++ b/PSZoom/Public/Users/Get-ZoomUserAssistants.ps1
@@ -52,7 +52,7 @@ function Get-ZoomUserAssistants {
         foreach ($id in $UserId) {
             $Request = [System.UriBuilder]"https://api.zoom.us/v2/users/$Id/assistants"
 
-           $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+           $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
     
             Write-Output $response
         }

--- a/PSZoom/Public/Users/Get-ZoomUserEmailStatus.ps1
+++ b/PSZoom/Public/Users/Get-ZoomUserEmailStatus.ps1
@@ -56,7 +56,7 @@ function Get-ZoomUserEmailStatus {
         $query.Add('email', $Email)
         $Request.Query = $query.ToString()
 
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
 
         Write-Output $response

--- a/PSZoom/Public/Users/Get-ZoomUserPermissions.ps1
+++ b/PSZoom/Public/Users/Get-ZoomUserPermissions.ps1
@@ -54,7 +54,7 @@ function Get-ZoomUserPermissions {
     process {
         $Request = [System.UriBuilder]"https://api.zoom.us/v2/users/$UserId/permissions"
 
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
 
         Write-Output $response

--- a/PSZoom/Public/Users/Get-ZoomUserSchedulers.ps1
+++ b/PSZoom/Public/Users/Get-ZoomUserSchedulers.ps1
@@ -53,7 +53,7 @@ function Get-ZoomUserSchedulers {
     process {
         $Request = [System.UriBuilder]"https://api.zoom.us/v2/users/$UserId/schedulers"
 
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
 
         Write-Output $response

--- a/PSZoom/Public/Users/Get-ZoomUserSettings.ps1
+++ b/PSZoom/Public/Users/Get-ZoomUserSettings.ps1
@@ -73,7 +73,7 @@ function Get-ZoomUserSettings {
             $Request.Query = $query.ToString()
         }
 
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
 
         Write-Output $response

--- a/PSZoom/Public/Users/Get-ZoomUserToken.ps1
+++ b/PSZoom/Public/Users/Get-ZoomUserToken.ps1
@@ -68,7 +68,7 @@ function Get-ZoomUserToken {
             $Request.Query = $query.ToString()
         }
 
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
 
         Write-Output $response

--- a/PSZoom/Public/Users/Get-ZoomUsers.ps1
+++ b/PSZoom/Public/Users/Get-ZoomUsers.ps1
@@ -158,7 +158,7 @@ function Get-ZoomUsers {
         
         $Request.Query = $query.ToString()
 
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
 
         if ($FullApiResponse) {

--- a/PSZoom/Public/Users/New-ZoomUser.ps1
+++ b/PSZoom/Public/Users/New-ZoomUser.ps1
@@ -163,7 +163,7 @@ function New-ZoomUser {
         $requestBody = $requestBody | ConvertTo-Json
 
         if ($PScmdlet.ShouldProcess) {
-            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $requestBody -Method Post
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method POST -ApiKey $ApiKey -ApiSecret $ApiSecret
 
             if ($passthru) {
                 Write-Output $Email

--- a/PSZoom/Public/Users/Remove-ZoomSpecificUserAssistant.ps1
+++ b/PSZoom/Public/Users/Remove-ZoomSpecificUserAssistant.ps1
@@ -62,7 +62,7 @@ function Remove-ZoomSpecificUserAssistant {
         foreach ($id in $UserId) {
             foreach ($aid in $AssistantId) {
                 $request = [System.UriBuilder]"https://api.zoom.us/v2/users/$id/assistants/$aid"
-                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method DELETE
+                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method DELETE -ApiKey $ApiKey -ApiSecret $ApiSecret
 
                 Write-Output $response
             }

--- a/PSZoom/Public/Users/Remove-ZoomSpecificUserScheduler.ps1
+++ b/PSZoom/Public/Users/Remove-ZoomSpecificUserScheduler.ps1
@@ -69,7 +69,7 @@ function Remove-ZoomSpecificUserScheduler {
                 if ($PScmdlet.ShouldProcess($user, "Remove $scheduler")) {
                     $request = [System.UriBuilder]"https://api.zoom.us/v2/users/$user/schedulers/$scheduler"
                     
-                    Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method DELETE
+                    Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method DELETE -ApiKey $ApiKey -ApiSecret $ApiSecret
 
                     if ($Passthru) {
                             Write-Output $UserId

--- a/PSZoom/Public/Users/Remove-ZoomUser.ps1
+++ b/PSZoom/Public/Users/Remove-ZoomUser.ps1
@@ -112,7 +112,7 @@ function Remove-ZoomUser {
             $request.Query = $query.ToString().ToLower()
             
             if ($PScmdlet.ShouldProcess($user, 'Remove')) {
-                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method DELETE
+                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method DELETE -ApiKey $ApiKey -ApiSecret $ApiSecret
 
                 if ($Passthru) {
                     Write-Output $UserId

--- a/PSZoom/Public/Users/Remove-ZoomUserAssistants.ps1
+++ b/PSZoom/Public/Users/Remove-ZoomUserAssistants.ps1
@@ -56,7 +56,7 @@ function Remove-ZoomUserAssistants {
         foreach ($user in $UserId) {
             $Request = [System.UriBuilder]"https://api.zoom.us/v2/users/$user/assistants"
     
-            Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method DELETE
+            Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method DELETE -ApiKey $ApiKey -ApiSecret $ApiSecret
  
             if ($Passthru) {
                 Write-Output $UserId

--- a/PSZoom/Public/Users/Remove-ZoomUserSchedulers.ps1
+++ b/PSZoom/Public/Users/Remove-ZoomUserSchedulers.ps1
@@ -57,7 +57,7 @@ function Remove-ZoomUserSchedulers {
         foreach ($user in $UserId) {
             $Request = [System.UriBuilder]"https://api.zoom.us/v2/users/$user/schedulers"
     
-            Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method DELETE
+            Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method DELETE -ApiKey $ApiKey -ApiSecret $ApiSecret
 
             if ($Passthru) {
                 Write-Output $UserId

--- a/PSZoom/Public/Users/Revoke-ZoomUserSsoToken.ps1
+++ b/PSZoom/Public/Users/Revoke-ZoomUserSsoToken.ps1
@@ -55,7 +55,7 @@ function Revoke-ZoomUserSsoToken {
     process {
         foreach ($user in $UserId) {
             $request = [System.UriBuilder]"https://api.zoom.us/v2/users/$user/token"
-            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method DELETE
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Method DELETE -ApiKey $ApiKey -ApiSecret $ApiSecret
 
             if ($Passthru) {
                 Write-Output $UserId

--- a/PSZoom/Public/Users/Update-ZoomProfilePicture.ps1
+++ b/PSZoom/Public/Users/Update-ZoomProfilePicture.ps1
@@ -76,7 +76,7 @@ function Update-ZoomProfilePicture {
                 "--$boundary--"
             ) -join $LF
     
-            $response = Invoke-ZoomRestMethod -Uri $request.Uri -ContentType "multipart/form-data; boundary=`"$boundary`"" -Headers $headers -Body $requestBody -Method POST
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -ContentType "multipart/form-data; boundary=`"$boundary`"" -Headers ([ref]$headers) -Body $requestBody -Method POST -ApiKey $ApiKey -ApiSecret $ApiSecret
 
             Write-Output $response
         }

--- a/PSZoom/Public/Users/Update-ZoomUser.ps1
+++ b/PSZoom/Public/Users/Update-ZoomUser.ps1
@@ -192,7 +192,7 @@ function Update-ZoomUser {
             $RequestBody = $RequestBody | ConvertTo-Json
 
             if ($pscmdlet.ShouldProcess) {
-                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $Headers -Body $RequestBody -Method PATCH
+                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $requestBody -Method PATCH -ApiKey $ApiKey -ApiSecret $ApiSecret
         
                 if (-not $PassThru) {
                     Write-Output $response

--- a/PSZoom/Public/Users/Update-ZoomUserEmail.ps1
+++ b/PSZoom/Public/Users/Update-ZoomUserEmail.ps1
@@ -72,7 +72,7 @@ function Update-ZoomUserEmail {
 
         $requestBody = $requestBody | ConvertTo-Json
 
-        Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $requestBody -Method PUT
+        Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $requestBody -Method PUT -ApiKey $ApiKey -ApiSecret $ApiSecret
 
         if ($Passthru) {
             Write-Output $UserId

--- a/PSZoom/Public/Users/Update-ZoomUserPassword.ps1
+++ b/PSZoom/Public/Users/Update-ZoomUserPassword.ps1
@@ -74,7 +74,7 @@ function Update-ZoomUserpassword {
             $requestBody = $requestBody | ConvertTo-Json
 
             if ($PSCmdlet.ShouldProcess) {
-                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $Headers -Body $requestBody -Method PUT
+                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $requestBody -Method PUT -ApiKey $ApiKey -ApiSecret $ApiSecret
 
                 if (-not $PassThru) {
                     Write-Output $response

--- a/PSZoom/Public/Users/Update-ZoomUserSettings.ps1
+++ b/PSZoom/Public/Users/Update-ZoomUserSettings.ps1
@@ -955,7 +955,7 @@ function Update-ZoomUserSettings {
             $requestBody = $requestBody | ConvertTo-Json
 
             if ($pscmdlet.ShouldProcess) {
-                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $requestBody -Method Patch
+                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $requestBody -Method PATCH -ApiKey $ApiKey -ApiSecret $ApiSecret
 
                 if (-not $PassThru) {
                     Write-Output $response

--- a/PSZoom/Public/Users/Update-ZoomUserStatus.ps1
+++ b/PSZoom/Public/Users/Update-ZoomUserStatus.ps1
@@ -68,7 +68,7 @@ function Update-ZoomUserStatus {
             $requestBody = $requestBody | ConvertTo-Json
     
             if ($PScmdlet.ShouldProcess($user, $Action)) {
-                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $Headers -Body $requestBody -Method PUT
+                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $requestBody -Method PUT -ApiKey $ApiKey -ApiSecret $ApiSecret
 
                 if ($PassThru) {
                     Write-Output $UserId

--- a/PSZoom/Public/Webinars/Get-ZoomWebinar.ps1
+++ b/PSZoom/Public/Webinars/Get-ZoomWebinar.ps1
@@ -84,7 +84,7 @@ function Get-ZoomWebinar {
         }      
 
         $Request.Query = $query.toString()
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $RequestBody -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
         Write-Output $response
     }

--- a/PSZoom/Public/Webinars/Get-ZoomWebinarPanelists.ps1
+++ b/PSZoom/Public/Webinars/Get-ZoomWebinarPanelists.ps1
@@ -61,7 +61,7 @@ function Get-ZoomWebinarPanelists {
 
     process {
         $request = [System.UriBuilder]"https://api.zoom.us/v2/webinars/$webinarId/panelists"
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $RequestBody -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
 
         Write-Output $response
     }

--- a/PSZoom/Public/Webinars/Get-ZoomWebinarsFromUser.ps1
+++ b/PSZoom/Public/Webinars/Get-ZoomWebinarsFromUser.ps1
@@ -81,7 +81,7 @@ function Get-ZoomWebinarsFromUser {
             $query.Add('page_number', $PageNumber)
             $request.Query = $query.ToString()
             $request.Query = $query.toString()
-            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Body $RequestBody -Method GET
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
     
             Write-Output $response
         }

--- a/PSZoom/Public/Webinars/Get-ZoomWebinarsFromUser.ps1
+++ b/PSZoom/Public/Webinars/Get-ZoomWebinarsFromUser.ps1
@@ -79,7 +79,7 @@ function Get-ZoomWebinarsFromUser {
             $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)  
             $query.Add('page_size', $PageSize)
             $query.Add('page_number', $PageNumber)
-            $request.Query = $query.ToString()
+            $request.Query = $query.toString()
             $request.Query = $query.toString()
             $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers ([ref]$Headers) -Body $RequestBody -Method GET -ApiKey $ApiKey -ApiSecret $ApiSecret
     


### PR DESCRIPTION
This PR fixes issue #26 

When sending an API request to Zoom, add logic to check the expiration date of the API token and update it if it has expired.