### PR TITLE
Fixed reference

### DIFF
--- a/PSZoom/Public/IMGroups/Add-ZoomIMDirectoryGroupMembers.ps1
+++ b/PSZoom/Public/IMGroups/Add-ZoomIMDirectoryGroupMembers.ps1
@@ -75,7 +75,7 @@ function Add-ZoomIMDirectoryGroupMembers  {
             }
         }
 
-        if ($PSBoundParameters.ContainsKey('MemberIds')) {
+        if ($PSBoundParameters.ContainsKey('MemberId')) {
             $MemberId | ForEach-Object {
                 $members.Add(@{id = $_})
             }


### PR DESCRIPTION
Original was referring to MemberIds parameter. Fixed to reference MemberId