### PR TITLE
O auth/o auth support

### DIFF
--- a/PSZoom/Private/New-OAuth.ps1
+++ b/PSZoom/Private/New-OAuth.ps1
@@ -1,0 +1,77 @@
+function New-OAuth {
+
+    <#
+    .SYNOPSIS
+    Retrieves the Zoom OAuth API token
+    .DESCRIPTION
+    Retrieves the Zoom OAuth API token
+
+    .PARAMETER ClientID
+    Client ID of the Zoom App
+
+    .PARAMETER ClientSecret
+    Client Secret of the Zoom App
+
+    .PARAMETER AccountID
+    Account ID of the Zoom App
+
+    .OUTPUTS
+    Zoom API Response
+
+    .NOTES
+    Version:        1.0
+    Author:         noaboa97
+    Creation Date:  20.07.2022
+    Purpose/Change: Initial function development
+  
+    .EXAMPLE
+    $clientid = "YourClientID"
+    $clientsecret = "YourClientSecret"
+    $AccountID = "YourAccountID"
+
+    New-OAuth -ClientID $clientid -ClientSecret $clientsecret -AccountID $AccountID
+
+    .EXAMPLE
+    $token = New-OAuth -ClientID $clientid -ClientSecret $clientsecret -AccountID $AccountID
+
+    .LINK
+    https://marketplace.zoom.us/docs/guides/build/server-to-server-oauth-app/
+
+    .LINK
+    https://marketplace.zoom.us/docs/guides/auth/oauth
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(valuefrompipeline = $true, mandatory = $true, HelpMessage = "Enter Zoom App Client ID:", Position = 0)]
+        [String]
+        $ClientID,
+
+        [Parameter(valuefrompipeline = $true, mandatory = $true, HelpMessage = "Enter Zoom App Client Secret:", Position = 1)]
+        [String]
+        $ClientSecret,
+
+        [Parameter(valuefrompipeline = $true, mandatory = $true, HelpMessage = "Enter Zoom App Account ID", Position = 2)]
+        [String]
+        $AccountID
+    )
+
+
+    $Uri = "https://zoom.us/oauth/token?grant_type=account_credentials&account_id={0}" -f $AccountID
+
+    #Encoding of the client data
+    $IDSecret = $ClientID + ":" + $ClientSecret 
+    $EncodedIDSecret = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($IDSecret))
+
+    $headers = @{
+        "Authorization" = "Basic $EncodedIDSecret"  
+    }
+            
+    # Maybe add some error handling
+    $response = Invoke-WebRequest -uri $Uri -headers $headers -Method Post 
+
+    $token = ($response.content | ConvertFrom-Json).access_token 
+
+    return $token
+
+}

--- a/PSZoom/Public/Utils/New-ZoomApiToken.ps1
+++ b/PSZoom/Public/Utils/New-ZoomApiToken.ps1
@@ -35,7 +35,28 @@ function New-ZoomApiToken {
     )
 
     $Credentials = Get-ZoomApiCredentials -ZoomApiKey $ApiKey -ZoomApiSecret $ApiSecret
-    $Token = New-Jwt -Algorithm 'HS256' -type 'JWT' -Issuer $Credentials.ApiKey -SecretKey $Credentials.ApiSecret -ValidforSeconds $ValidforSeconds
+
+    if (-not $Global:ZoomAppType) {
+
+        Write-Verbose "Creating new JWT Token"
+        $Token = New-Jwt -Algorithm 'HS256' -type 'JWT' -Issuer $Credentials.ApiKey -SecretKey $Credentials.ApiSecret -ValidforSeconds $ValidforSeconds
+
+    }
+    elseif ($Global:ZoomAppType -eq "ServerOAuth") {
+
+        if (-not $Global:ZoomAccountID) {
+
+            throw "Global variable `"AccountID`" not defined"
+
+        }
+        else {
+
+            $Token = New-OAuth -ClientID $Credentials.ApiKey -ClientSecret $Credentials.ApiSecret -AccountID $Global:ZoomAccountID
+
+        }
+        
+    }
     
     Write-Output $Token
+
 }

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Import-Module PSZoom
 ```
 
 # Using your API key and API secret #
-All commands require an API key and API secret. Currently PSZoom uses only JWT for authorization.  You can generate 
-the JWT key/secret from https://marketplace.zoom.us/develop/create, then click on  'Create' under JWT.  Note that in 
-addition to the key/secret, Zoom also provides an IM Chat History Token, this is not to be confused with the key/secret.  
+All commands require an API key (ClientID) and API secret. Currently PSZoom uses JWT (which will deprecated on 6/1/2023) and Server-to-Server OAuth authorization.  You can generate 
+the JWT or Server-to-Server OAuth key/secret from https://marketplace.zoom.us/develop/create, then click on  'Create' under JWT or Server-to-Server OAuth.  Note that in 
+addition to the JWT key/secret, Zoom also provides an IM Chat History Token, this is not to be confused with the key/secret. 
   
 For ease of use, each command looks for these variables automatically in the following order:  
     In the global scope for ZoomApiKey and ZoomApiSecret  
@@ -45,6 +45,9 @@ For ease of use, each command looks for these variables automatically in the fol
 import-module PSZoom
 $Global:ZoomApiKey    = 'API_Key_Goes_Here'  
 $Global:ZoomApiSecret = 'API_Secret_Goes_Here'  
+$Global:ZoomAccountID = 'Account_ID_Goes_Here'
+# Only if you want to use Server-to-Server OAuth 
+$Global:ZoomAppType = "ServerOAuth"
 Get-ZoomMeeting 123456789
 ```
 


### PR DESCRIPTION
Added feature OAuth for Server-to-Server Zoom app.

Introduced new function New-OAuth which retrieves the api access token.

Edited New-ZoomApiToken to check for Zoom app type (new global variable). If empty it will use JWT. 
Also introduced another new global variable "ZoomAccountID" which is needed for StS OAuth. 

Edited the documentation to include the new global variables and notice of JWT beeing deprecated by 2023.

Tested manual locally with Get-ZoomUsers

Resolves #68