### PR TITLE
Merge (#79)

### DIFF
--- a/PSZoom/PSZoom.psd1
+++ b/PSZoom/PSZoom.psd1
@@ -13,7 +13,7 @@
     
     # Version number of this module.
 
-    ModuleVersion = '2.0.0.0'
+    ModuleVersion = '2.0.2.0'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/PSZoom/Public/Groups/Add-ZoomGroupMember.ps1
+++ b/PSZoom/Public/Groups/Add-ZoomGroupMember.ps1
@@ -90,7 +90,7 @@ function Add-ZoomGroupMember  {
             }
         }
 
-        if ($PSBoundParameters.ContainsKey('MemberIds')) {
+        if ($PSBoundParameters.ContainsKey('MemberId')) {
             $MemberId | ForEach-Object {
                 $members.Add(@{id = $_})
             }

--- a/PSZoom/Public/Phone/Get-ZoomPhoneUsers.ps1
+++ b/PSZoom/Public/Phone/Get-ZoomPhoneUsers.ps1
@@ -61,7 +61,7 @@ function Get-ZoomPhoneUsers {
      )
 
     process {
-        $request = [System.UriBuilder]'https://api.zoom.us/v2/phone/users/'
+        $request = [System.UriBuilder]'https://api.zoom.us/v2/phone/users'
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
         $query.Add('page_size', $PageSize)
         $query.Add('next_page_token', $NextPageToken)

--- a/PSZoom/Public/Users/Remove-ZoomUser.ps1
+++ b/PSZoom/Public/Users/Remove-ZoomUser.ps1
@@ -4,13 +4,16 @@
 Delete a user on your account.
 
 .DESCRIPTION
-Delete a user on your account.
+Use this API to disassociate (unlink) a user or permanently delete a user. 
 
 .PARAMETER Action
 Delete action options:
 disassociate - Disassociate a user. This is the default.
 delete - Permanently delete a user.
 Note: To delete pending user in the account, use disassociate.
+
+.PARAMETER EncryptedEmail
+Whether the email address passed for the userId value is an encrypted email address.
 
 .PARAMETER TransferEmail
 Transfer email.
@@ -23,6 +26,9 @@ Transfer webinar.
 
 .PARAMETER TransferRecording
 Transfer recording.
+
+.PARAMETER Transferwhiteboard
+When you delete the user, whether to transfer all their Zoom Whiteboard data to another user.
 
 .OUTPUTS
 No output. Can use Passthru switch to pass UserId to output.
@@ -50,6 +56,10 @@ function Remove-ZoomUser {
         [Parameter(ValueFromPipelineByPropertyName = $True)]
         [ValidateSet('disassociate', 'delete')]
         [string]$Action = 'disassociate',
+
+        [Parameter(ValueFromPipelineByPropertyName = $True)]
+        [Alias('encrypted_email')]
+        [switch]$EncryptedEmail,
         
         [Parameter(ValueFromPipelineByPropertyName = $True)]
         [Alias('transfer_email')]
@@ -67,6 +77,10 @@ function Remove-ZoomUser {
         [Alias('transfer_recording')]
         [switch]$TransferRecording,
 
+        [Parameter(ValueFromPipelineByPropertyName = $True)]
+        [Alias('transfer_whiteboard')]
+        [switch]$TransferWhiteboard,
+
         [switch]$Passthru
     )
 
@@ -75,6 +89,10 @@ function Remove-ZoomUser {
             $request = [System.UriBuilder]"https://api.zoom.us/v2/users/$user"
             $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
             $query.Add('action', $Action)
+
+            if ($PSBoundParameters.ContainsKey('EncryptedEmail')) {
+                $query.Add('encrypted_email', $EncryptedEmail)
+            }
 
             if ($PSBoundParameters.ContainsKey('TransferEmail')) {
                 $query.Add('transfer_email', $TransferEmail)
@@ -90,6 +108,10 @@ function Remove-ZoomUser {
 
             if ($PSBoundParameters.ContainsKey('TransferRecording')) {
                 $query.Add('transfer_recording', $TransferRecording)
+            }
+
+            if ($PSBoundParameters.ContainsKey('TransferWhiteboard')) {
+                $query.Add('transfer_whiteboard', $Transferwhiteboard)
             }
             
             $request.Query = $query.ToString().ToLower()

--- a/PSZoom/Public/Utils/New-OAuthToken.ps1
+++ b/PSZoom/Public/Utils/New-OAuthToken.ps1
@@ -68,7 +68,7 @@ function New-OAuthToken {
             
     # Maybe add some error handling
     try {
-        $response = Invoke-WebRequest -uri $uri -headers $headers -Method Post
+        $response = Invoke-WebRequest -uri $uri -headers $headers -Method Post -UseBasicParsing
     } catch {
         $_
     }


### PR DESCRIPTION
* Updated Remove-ZoomUser (#72)

* Fix get-zoomphoneusers error 400 bad request (#74)

* Fixed next page token not working for phone users

Removed page_number in favor of next_page_token

* Fixed error 400 bad request

Removed forward slash after users in the request uri, as it results in a error 400 bad request.

* Update PSZoom.psd1

* Update New-OAuthToken.ps1 (#78)

Add -UseBasicParsing to Invoke-WebRequest to deal with Internet Explorer engine issues.

* Increment version

Invoke web request now uses -usebasicparsing for backwards compatibility with PowerShell 5.0 on systems without Internet Explorer.

* mapped to parameter name not alias (#76)

Co-authored-by: Certitude <johndoe@example.com>

Co-authored-by: Dylan Pinsonneault <dylanp2222@gmail.com>
Co-authored-by: IdahoVandal <78939229+IdahoVandal@users.noreply.github.com>
Co-authored-by: Victor Maso <70488201+victormaso@users.noreply.github.com>
Co-authored-by: Certitude <johndoe@example.com>