### PR TITLE
Change PSZoomToken scope to Script

### DIFF
--- a/PSZoom/Public/Utils/Connect-PSZoom.ps1
+++ b/PSZoom/Public/Utils/Connect-PSZoom.ps1
@@ -3,7 +3,7 @@
 Use this cmdlet to retrieve a token from Zoom.
 
 .DESCRIPTION
-Assigns a token to the variable $Global:PSZoomToken which is used by all cmdlets when making requests to Zoom.
+Assigns a token to the variable $Script:PSZoomToken which is used by all cmdlets when making requests to Zoom.
 
 .EXAMPLE
 Connect-PSZoom -AccountID 'your_account_id' -ClientID 'your_client_id' -ClientSecret 'your_client_secret'
@@ -36,7 +36,7 @@ function Connect-PSZoom {
 
     try {
         $token = New-OAuthToken -AccountID $AccountID -ClientID $ClientID -ClientSecret $ClientSecret
-        $Global:PSZoomToken = $token
+        $Script:PSZoomToken = $token
     } catch {
         if ($_.exception.Response) {
             if ($PSVersionTable.PSVersion.Major -lt 6) {


### PR DESCRIPTION
Fix: Store API Key/Secret in module scope variable #54

With the Server-to-Server OAuth token changes, and the $PSZoomToken variable being stored in the Global scope, it is possible for scripts to run over eachother (especially if you're doing a long running job) and overwrite the token being used. This change is designed to address this issue.

I've done some relatively basic testing, but this appears to work without issue and be the only change needed to address this.