### PR TITLE
Typo fix in Invoke-ZoomRestMethod.ps1

### DIFF
--- a/PSZoom/Public/Utils/Invoke-ZoomRestMethod.ps1
+++ b/PSZoom/Public/Utils/Invoke-ZoomRestMethod.ps1
@@ -91,7 +91,7 @@ function Invoke-ZoomRestMethod {
         RetryIntervalSec                = 'RetryIntervalSec'
         SessionVariable                 = 'SessionVariable'
         SkipCertificateCheck            = 'SkipCertificateCheck'
-        SkipHeaderValidatio             = 'SkipHeaderValidation'
+        SkipHeaderValidation            = 'SkipHeaderValidation'
         SkipHttpErrorCheck              = 'SkipHttpErrorCheck'
         SslProtocol                     = 'SslProtocol'
         StatusCodeVariable              = 'StatusCodeVariable'


### PR DESCRIPTION
Line 94 in Invoke-ZoomRestMethod.ps1 contained:

`SkipHeaderValidatio             = 'SkipHeaderValidation'`

changed to:

`SkipHeaderValidation            = 'SkipHeaderValidation'`