### PR TITLE
fixed not initialized array in Update-ZoomMeeting

### DIFF
--- a/PSZoom/Public/Meetings/Update-ZoomMeeting.ps1
+++ b/PSZoom/Public/Meetings/Update-ZoomMeeting.ps1
@@ -346,6 +346,8 @@ function Update-ZoomMeeting {
   process {
     $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId"
 
+    $requestBody=@{}
+
     if ($PSBoundParameters.ContainsKey('OccurrenceId')) {
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)  
         $query.Add('occurrence_id', $OccurrenceId)


### PR DESCRIPTION
$requestBody was not initialized. Update operation always failed when the script trying to add items to a null array.