### PR TITLE
Zoomgov Support and Zoom phone Functions

### DIFF
--- a/PSZoom/Public/Account/Get-ZoomAccount.ps1
+++ b/PSZoom/Public/Account/Get-ZoomAccount.ps1
@@ -32,7 +32,7 @@ function Get-ZoomAccount {
     )
 
     process {
-        $request = [System.UriBuilder]"https://api.zoom.us/v2/accounts/$id"    
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/accounts/$id"    
         $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET
         
         Write-Output $response

--- a/PSZoom/Public/Account/Get-ZoomAccountSettings.ps1
+++ b/PSZoom/Public/Account/Get-ZoomAccountSettings.ps1
@@ -20,7 +20,7 @@ function Get-ZoomAccountSettings {
     param ()
 
     process {
-        $request = [System.UriBuilder]"https://api.zoom.us/v2/accounts/me/settings"        
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/accounts/me/settings"        
         $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET
         
         Write-Output $response        

--- a/PSZoom/Public/Account/Get-ZoomAccounts.ps1
+++ b/PSZoom/Public/Account/Get-ZoomAccounts.ps1
@@ -28,7 +28,7 @@ function Get-ZoomAccounts {
      )
 
     process {
-        $request = [System.UriBuilder]"https://api.zoom.us/v2/accounts"
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/accounts"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
         $query.Add('page_size', $PageSize)
 	

--- a/PSZoom/Public/CloudRecording/Get-ZoomAccountRecordings.ps1
+++ b/PSZoom/Public/CloudRecording/Get-ZoomAccountRecordings.ps1
@@ -92,7 +92,7 @@ function Get-ZoomAccountRecordings {
 
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/accounts/$AccountId/recordings"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/accounts/$AccountId/recordings"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
 
         if ($PSBoundParameters.ContainsKey('PageSize')) {

--- a/PSZoom/Public/CloudRecording/Get-ZoomMeetingRecordings.ps1
+++ b/PSZoom/Public/CloudRecording/Get-ZoomMeetingRecordings.ps1
@@ -37,7 +37,7 @@ function Get-ZoomMeetingRecordings {
      )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/recordings"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId/recordings"
 
         $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $RequestBody -Method GET
 

--- a/PSZoom/Public/CloudRecording/Get-ZoomMeetingRecordingsSettings.ps1
+++ b/PSZoom/Public/CloudRecording/Get-ZoomMeetingRecordingsSettings.ps1
@@ -35,7 +35,7 @@ function Get-ZoomMeetingRecordingsSettings {
         $MeetingId = [uri]::EscapeDataString($MeetingId)
         $MeetingId = [uri]::EscapeDataString($MeetingId)
 
-        $request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/recordings/settings"
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId/recordings/settings"
 
         if ($pscmdlet.ShouldProcess) {
             $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $requestBody -Method GET

--- a/PSZoom/Public/CloudRecording/Get-ZoomRecordings.ps1
+++ b/PSZoom/Public/CloudRecording/Get-ZoomRecordings.ps1
@@ -92,7 +92,7 @@ function Get-ZoomRecordings {
 
     process {
         foreach ($user in $Userid) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/users/$user/recordings"
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$user/recordings"
             $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
 
             if ($PSBoundParameters.ContainsKey('PageSize')) {

--- a/PSZoom/Public/CloudRecording/Remove-ZoomMeetingRecordingFile.ps1
+++ b/PSZoom/Public/CloudRecording/Remove-ZoomMeetingRecordingFile.ps1
@@ -56,7 +56,7 @@ function Remove-ZoomMeetingRecordingFile {
 
     process {
         foreach($RecId in $RecordingId) {
-            $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/recordings/$RecId"
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId/recordings/$RecId"
             $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
             $query.Add('action', $Action)
             $Request.Query = $query.ToString()

--- a/PSZoom/Public/CloudRecording/Remove-ZoomMeetingRecordings.ps1
+++ b/PSZoom/Public/CloudRecording/Remove-ZoomMeetingRecordings.ps1
@@ -50,7 +50,7 @@ function Remove-ZoomMeetingRecordings {
 
     process {
         foreach($Id in $MeetingId) {
-            $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$Id/recordings"
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$Id/recordings"
             $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
             $query.Add('action', $Action)
             $Request.Query = $query.ToString()

--- a/PSZoom/Public/CloudRecording/Show-ZoomMeetingRecordings.ps1
+++ b/PSZoom/Public/CloudRecording/Show-ZoomMeetingRecordings.ps1
@@ -41,7 +41,7 @@ function Show-ZoomMeetingRecordings {
         $MeetingId = [uri]::EscapeDataString($MeetingId)
         $MeetingId = [uri]::EscapeDataString($MeetingId)
         
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/recordings/status"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId/recordings/status"
 
         
         $requestBody = @{}

--- a/PSZoom/Public/CloudRecording/Update-ZoomMeetingRecordingsSettings.ps1
+++ b/PSZoom/Public/CloudRecording/Update-ZoomMeetingRecordingsSettings.ps1
@@ -130,7 +130,7 @@ function Update-ZoomMeetingRecordingsSettings {
         $MeetingId = [uri]::EscapeDataString($MeetingId)
         $MeetingId = [uri]::EscapeDataString($MeetingId)
 
-        $request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/recordings/settings"
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId/recordings/settings"
         $requestBody = @{}
 
         if ($PSBoundParameters.ContainsKey('ShareRecording')) {

--- a/PSZoom/Public/Groups/Add-ZoomGroupMember.ps1
+++ b/PSZoom/Public/Groups/Add-ZoomGroupMember.ps1
@@ -105,7 +105,7 @@ function Add-ZoomGroupMember  {
         $requestBody = $requestBody | ConvertTo-Json
 
         foreach ($Id in $GroupId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$Id/members"
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/groups/$Id/members"
             if ($PScmdlet.ShouldProcess($members, 'Add')) {
                 $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $RequestBody -Method POST
 

--- a/PSZoom/Public/Groups/Get-ZoomGroup.ps1
+++ b/PSZoom/Public/Groups/Get-ZoomGroup.ps1
@@ -27,7 +27,7 @@ function Get-ZoomGroup  {
     )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$GroupId"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/groups/$GroupId"
 
         $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET
 

--- a/PSZoom/Public/Groups/Get-ZoomGroupLockSettings.ps1
+++ b/PSZoom/Public/Groups/Get-ZoomGroupLockSettings.ps1
@@ -35,7 +35,7 @@ function Get-ZoomGroupLockSettings  {
     )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$GroupId/lock_settings"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/groups/$GroupId/lock_settings"
 
         $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET
 

--- a/PSZoom/Public/Groups/Get-ZoomGroupMembers.ps1
+++ b/PSZoom/Public/Groups/Get-ZoomGroupMembers.ps1
@@ -56,7 +56,7 @@ function Get-ZoomGroupMembers  {
     )
 
     process {
-        $request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$GroupId/members"
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/groups/$GroupId/members"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
         $query.Add('page_size', $PageSize)
         $query.Add('next_page_token', $NextPageToken)

--- a/PSZoom/Public/Groups/Get-ZoomGroupSettings.ps1
+++ b/PSZoom/Public/Groups/Get-ZoomGroupSettings.ps1
@@ -35,7 +35,7 @@ function Get-ZoomGroupSettings  {
     )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$GroupId/settings"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/groups/$GroupId/settings"
         $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET
 
         Write-Output $response   

--- a/PSZoom/Public/Groups/Get-ZoomGroups.ps1
+++ b/PSZoom/Public/Groups/Get-ZoomGroups.ps1
@@ -45,7 +45,7 @@ function Get-ZoomGroups  {
     )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/groups"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/groups"
 
         $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET
 

--- a/PSZoom/Public/Groups/New-ZoomGroup.ps1
+++ b/PSZoom/Public/Groups/New-ZoomGroup.ps1
@@ -36,7 +36,7 @@ function New-ZoomGroup {
     )
 
     begin {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/groups"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/groups"
     }
 
     process {

--- a/PSZoom/Public/Groups/Remove-ZoomGroup.ps1
+++ b/PSZoom/Public/Groups/Remove-ZoomGroup.ps1
@@ -36,7 +36,7 @@ function Remove-ZoomGroup {
 
     process {
         foreach ($Id in $GroupID) {
-            $Request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$Id"
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/groups/$Id"
             if ($PSCmdlet.ShouldProcess($Id, "Remove")) {
                 $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method DELETE
                 Write-Verbose "Group $Id deleted."

--- a/PSZoom/Public/Groups/Remove-ZoomGroupMembers.ps1
+++ b/PSZoom/Public/Groups/Remove-ZoomGroupMembers.ps1
@@ -47,7 +47,7 @@ function Remove-ZoomGroupMembers {
         foreach ($GroupId in $GroupIDs) {
             #Need to add API rate limiting
             foreach ($MemberId in $MemberIds) {
-                $Request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$GroupId/members/$MemberId"
+                $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/groups/$GroupId/members/$MemberId"
                 
                 if ($PScmdlet.ShouldProcess) {
                     Write-Verbose "Removing $MemberId from $GroupId."

--- a/PSZoom/Public/Groups/Update-ZoomGroup.ps1
+++ b/PSZoom/Public/Groups/Update-ZoomGroup.ps1
@@ -45,7 +45,7 @@ function Update-ZoomGroup  {
     )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$GroupId"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/groups/$GroupId"
 
         $requestBody = @{
             name = $Name

--- a/PSZoom/Public/Groups/Update-ZoomGroupLockSettings.ps1
+++ b/PSZoom/Public/Groups/Update-ZoomGroupLockSettings.ps1
@@ -555,7 +555,7 @@ function Update-ZoomGroupLockSettings  {
         $requestBody = $requestBody | ConvertTo-Json
 
         foreach ($id in $GroupId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$GroupId/lock_settings"
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/groups/$GroupId/lock_settings"
 
             $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $requestBody -Method PATCH
 

--- a/PSZoom/Public/Groups/Update-ZoomGroupSettings.ps1
+++ b/PSZoom/Public/Groups/Update-ZoomGroupSettings.ps1
@@ -554,7 +554,7 @@ function Update-ZoomGroupSettings  {
         $requestBody = $requestBody | ConvertTo-Json
 
         foreach ($id in $GroupId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/groups/$GroupId/settings"
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/groups/$GroupId/settings"
 
             $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $requestBody -Method PATCH
 

--- a/PSZoom/Public/IMGroups/Add-ZoomIMDirectoryGroupMembers.ps1
+++ b/PSZoom/Public/IMGroups/Add-ZoomIMDirectoryGroupMembers.ps1
@@ -75,7 +75,7 @@ function Add-ZoomIMDirectoryGroupMembers  {
         $requestBody = $requestBody | ConvertTo-Json
 
         foreach ($Id in $GroupId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/im/groups/$Id/members"
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/im/groups/$Id/members"
             if ($PScmdlet.ShouldProcess($members, 'Add')) {
                 $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $RequestBody -Method POST
 

--- a/PSZoom/Public/Meetings/Add-ZoomMeetingRegistrant.ps1
+++ b/PSZoom/Public/Meetings/Add-ZoomMeetingRegistrant.ps1
@@ -157,7 +157,7 @@ function Add-ZoomMeetingRegistrant {
     )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/registrants"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId/registrants"
 
         if ($PSBoundParameters.ContainsKey('OcurrenceIds')) {
             $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty) 

--- a/PSZoom/Public/Meetings/Get-ZoomEndedMeetingInstances.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomEndedMeetingInstances.ps1
@@ -28,7 +28,7 @@ function Get-ZoomEndedMeetingInstances {
      )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/past_meetings/$MeetingId/instances"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/past_meetings/$MeetingId/instances"
         $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $RequestBody -Method GET
         
         Write-Output $response

--- a/PSZoom/Public/Meetings/Get-ZoomMeeting.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomMeeting.ps1
@@ -46,7 +46,7 @@ function Get-ZoomMeeting {
      )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
 
         if ($PSBoundParameters.ContainsKey('OccurrenceId')) {

--- a/PSZoom/Public/Meetings/Get-ZoomMeetingInvitation.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomMeetingInvitation.ps1
@@ -28,7 +28,7 @@ function Get-ZoomMeetingInvitation {
      )
 
     process {
-        $Uri = "https://api.zoom.us/v2/meetings/$MeetingId/invitation"
+        $Uri = "https://api.$ZoomURI/v2/meetings/$MeetingId/invitation"
         
         $response = Invoke-ZoomRestMethod -Uri $Uri -Method GET
         

--- a/PSZoom/Public/Meetings/Get-ZoomMeetingPoll.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomMeetingPoll.ps1
@@ -38,7 +38,7 @@ function Get-ZoomMeetingPoll {
      )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/polls/$PollId"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId/polls/$PollId"
     
         $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $RequestBody -Method GET
         

--- a/PSZoom/Public/Meetings/Get-ZoomMeetingPolls.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomMeetingPolls.ps1
@@ -30,7 +30,7 @@ function Get-ZoomMeetingPolls {
      )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/polls"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId/polls"
    
         $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $RequestBody -Method GET
         

--- a/PSZoom/Public/Meetings/Get-ZoomMeetingRegistrants.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomMeetingRegistrants.ps1
@@ -48,7 +48,7 @@ function Get-ZoomMeetingRegistrants {
     )
 
     process {
-        $request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/registrants"
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId/registrants"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)  
         $query.Add('status', $Status)
         $query.Add('page_size', $PageSize)

--- a/PSZoom/Public/Meetings/Get-ZoomMeetings.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomMeetings.ps1
@@ -98,7 +98,7 @@ function Get-ZoomMeetings {
 
     process {
         if ($PsCmdlet.ParameterSetName -eq 'Default') {
-                $Request = [System.UriBuilder]"https://api.zoom.us/v2/metrics/meetings"
+                $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/metrics/meetings"
                 $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
                 $query.Add('page_size', $PageSize)
                 $query.Add('type', $Type.ToLower())

--- a/PSZoom/Public/Meetings/Get-ZoomMeetingsFromUser.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomMeetingsFromUser.ps1
@@ -55,7 +55,7 @@ function Get-ZoomMeetingsFromUser {
 
         foreach ($id in $UserId) {
 
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/users/$id/meetings"
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$id/meetings"
             $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)  
             $query.add('type', $Type)
             $query.add('page_size', $PageSize)

--- a/PSZoom/Public/Meetings/Get-ZoomPastMeetingDetails.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomPastMeetingDetails.ps1
@@ -28,7 +28,7 @@ function Get-ZoomPastMeetingDetails {
      )
 
     process {
-        $Uri = "https://api.zoom.us/v2/past_meetings/$MeetingUuid"
+        $Uri = "https://api.$ZoomURI/v2/past_meetings/$MeetingUuid"
         
         $response = Invoke-ZoomRestMethod -Uri $Uri -Method GET
         

--- a/PSZoom/Public/Meetings/Get-ZoomPastMeetingParticipants.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomPastMeetingParticipants.ps1
@@ -37,7 +37,7 @@ function Get-ZoomPastMeetingParticipants {
      )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/past_meetings/$MeetingUuid/participants"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/past_meetings/$MeetingUuid/participants"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)  
         $query.Add('page_size', $PageSize)
 

--- a/PSZoom/Public/Meetings/Get-ZoomPastMeetingParticipantsMetrics.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomPastMeetingParticipantsMetrics.ps1
@@ -49,7 +49,7 @@ function Get-ZoomPastMeetingParticipantsMetrics {
      )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/metrics/meetings/$MeetingUuid/participants"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/metrics/meetings/$MeetingUuid/participants"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)  
         $query.Add('page_size', $PageSize)
         $query.Add('type', $Type)

--- a/PSZoom/Public/Meetings/Get-ZoomRegistrationQuestions.ps1
+++ b/PSZoom/Public/Meetings/Get-ZoomRegistrationQuestions.ps1
@@ -28,7 +28,7 @@ function Get-ZoomRegistrationQuestions {
      )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/registrants/questions"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId/registrants/questions"
     
         $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $RequestBody -Method GET
         

--- a/PSZoom/Public/Meetings/New-ZoomMeeting.ps1
+++ b/PSZoom/Public/Meetings/New-ZoomMeeting.ps1
@@ -609,7 +609,7 @@ function New-ZoomMeeting {
     )
     
     begin {
-        $Uri = "https://api.zoom.us/v2/users/$userId/meetings"
+        $Uri = "https://api.$ZoomURI/v2/users/$userId/meetings"
     }
     
     process {

--- a/PSZoom/Public/Meetings/New-ZoomMeetingPoll.ps1
+++ b/PSZoom/Public/Meetings/New-ZoomMeetingPoll.ps1
@@ -59,7 +59,7 @@ function New-ZoomMeetingPoll {
     )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/polls"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId/polls"
         $RequestBody = @{}
 
         if ($PSBoundParameters.ContainsKey('Title')) {

--- a/PSZoom/Public/Meetings/Remove-ZoomMeeting.ps1
+++ b/PSZoom/Public/Meetings/Remove-ZoomMeeting.ps1
@@ -44,7 +44,7 @@ function Remove-ZoomMeeting {
     )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId"
 
         if ($PSBoundParameters.ContainsKey('OccurrenceId') -or $PSBoundParameters.ContainsKey('ScheduleForReminder')) {
             $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)

--- a/PSZoom/Public/Meetings/Remove-ZoomMeetingPoll.ps1
+++ b/PSZoom/Public/Meetings/Remove-ZoomMeetingPoll.ps1
@@ -38,7 +38,7 @@ function Remove-ZoomMeetingPoll {
      )
 
     process {
-        $request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/polls/$PollId"
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId/polls/$PollId"
         $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $RequestBody -Method DELETE
         
         Write-Output $response

--- a/PSZoom/Public/Meetings/Update-ZoomMeeting.ps1
+++ b/PSZoom/Public/Meetings/Update-ZoomMeeting.ps1
@@ -344,7 +344,7 @@ function Update-ZoomMeeting {
   )
     
   process {
-    $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId"
+    $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId"
 
     $requestBody=@{}
 

--- a/PSZoom/Public/Meetings/Update-ZoomMeetingLiveStream.ps1
+++ b/PSZoom/Public/Meetings/Update-ZoomMeetingLiveStream.ps1
@@ -49,7 +49,7 @@ function Update-ZoomMeetingLiveStream {
      )
 
     process {
-        $uri = "https://api.zoom.us/v2/meetings/$MeetingId/livestream"
+        $uri = "https://api.$ZoomURI/v2/meetings/$MeetingId/livestream"
         $requestBody = @{
             'stream_url' = $StreamUrl
             'stream_key' = $StreamKey

--- a/PSZoom/Public/Meetings/Update-ZoomMeetingLiveStreamStatus.ps1
+++ b/PSZoom/Public/Meetings/Update-ZoomMeetingLiveStreamStatus.ps1
@@ -43,7 +43,7 @@ function Update-ZoomMeetingLiveStreamStatus {
      )
 
     process {
-        $Uri = "https://api.zoom.us/v2/meetings/$MeetingId/livestream/status"
+        $Uri = "https://api.$ZoomURI/v2/meetings/$MeetingId/livestream/status"
         $requestBody = @{}
 
         if ($PSBoundParameters.ContainsKey('StreamUrl')) {

--- a/PSZoom/Public/Meetings/Update-ZoomMeetingPoll.ps1
+++ b/PSZoom/Public/Meetings/Update-ZoomMeetingPoll.ps1
@@ -69,7 +69,7 @@ function Update-ZoomMeetingPoll {
     )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/polls/$PollId"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId/polls/$PollId"
         $requestBody = @{}
 
         if ($PSBoundParameters.ContainsKey('Title')) {

--- a/PSZoom/Public/Meetings/Update-ZoomMeetingRegistrantStatus.ps1
+++ b/PSZoom/Public/Meetings/Update-ZoomMeetingRegistrantStatus.ps1
@@ -49,7 +49,7 @@ function Update-ZoomMeetingRegistrantStatus {
      )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/registrants/status"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId/registrants/status"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
 
         if ($PSBoundParameters.ContainsKey('OcurrenceId')) {

--- a/PSZoom/Public/Meetings/Update-ZoomMeetingRegistrationQuestions.ps1
+++ b/PSZoom/Public/Meetings/Update-ZoomMeetingRegistrationQuestions.ps1
@@ -73,7 +73,7 @@ function Update-ZoomMeetingRegistrationQuestions {
 
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/registrants/questions"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId/registrants/questions"
         $requestBody = @{}
         
         if ($PSBoundParameters.ContainsKey('Questions')) {

--- a/PSZoom/Public/Meetings/Update-ZoomMeetingStatus.ps1
+++ b/PSZoom/Public/Meetings/Update-ZoomMeetingStatus.ps1
@@ -38,7 +38,7 @@ function Update-ZoomMeetingStatus {
     )
 
     process {
-        $request = [System.UriBuilder]"https://api.zoom.us/v2/meetings/$MeetingId/status"
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/meetings/$MeetingId/status"
 
         $requestBody = @{
             'action' = $Action

--- a/PSZoom/Public/Phone/Add-ZoomPhoneUserCallingPlans.ps1
+++ b/PSZoom/Public/Phone/Add-ZoomPhoneUserCallingPlans.ps1
@@ -1,0 +1,93 @@
+<#
+
+.SYNOPSIS
+Add initial calling plan to a Zoom Phone User
+                    
+.PARAMETER LicenseType
+License Type that is to applied to target phone account.
+Use following command to get available license types for Zoom instance.
+Get-ZoomPhoneCallingPlans
+
+.OUTPUTS
+No output. Can use Passthru switch to pass UserId to output.
+
+.EXAMPLE
+Add-ZoomPhoneUserCallingPlans -UserId askywakler@thejedi.com -Type 200
+
+.LINK
+https://developers.zoom.us/docs/api/rest/reference/phone/methods/#operation/assignCallingPlan
+
+.LINK
+https://developers.zoom.us/docs/api/rest/other-references/plans/
+
+#>
+
+function Add-ZoomPhoneUserCallingPlans {    
+    [CmdletBinding(SupportsShouldProcess = $True)]
+    Param(
+        [Parameter(
+            Mandatory = $True,       
+            ValueFromPipeline = $True,
+            ValueFromPipelineByPropertyName = $True,
+            Position = 0
+        )]
+        [ValidateLength(1, 128)]
+        [Alias('Email', 'Emails', 'EmailAddress', 'EmailAddresses', 'Id', 'ids', 'user_id', 'user', 'users', 'userids')]
+        [string[]]$UserId,
+
+        [Parameter(
+            Mandatory = $True, 
+            Position = 1
+        )]
+        [Alias('License_Type')]
+        [int]$LicenseType,
+
+        [switch]$PassThru
+    )
+    
+
+
+    process {
+        foreach ($user in $UserId) {
+            
+            if (!(Get-ZoomUserSettings -UserId $user | Select-Object -ExpandProperty "feature" | Select-Object -ExpandProperty "zoom_phone")) {
+
+                Update-ZoomUserSettings -UserId $user -ZoomPhone $True
+
+            }
+
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/users/$user/calling_plans"
+            $RequestBody = @{ }
+            $ChosenLicense = @{ }
+
+
+            $KeyValuePairs = @{
+                'type'    = $LicenseType
+            }
+
+            $KeyValuePairs.Keys | ForEach-Object {
+                if (-not ([string]::IsNullOrEmpty($KeyValuePairs.$_))) {
+                    $ChosenLicense.Add($_, $KeyValuePairs.$_)
+                }
+            }
+
+            $ChosenLicense = @($ChosenLicense)
+
+            $RequestBody.Add("calling_plans", $ChosenLicense)
+
+            $RequestBody = $RequestBody | ConvertTo-Json
+
+            if ($pscmdlet.ShouldProcess) {
+                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $requestBody -Method POST
+        
+                if (-not $PassThru) {
+                    Write-Output $response
+                }
+            }
+        }
+
+        if ($PassThru) {
+            Write-Output $UserId
+        }
+    }
+}

--- a/PSZoom/Public/Phone/Add-ZoomPhoneUserNumber.ps1
+++ b/PSZoom/Public/Phone/Add-ZoomPhoneUserNumber.ps1
@@ -58,7 +58,7 @@ function Add-ZoomPhoneUserNumber {
 
             }
 
-            $NumberInfo = Get-ZoomPhoneNumbers | Where-object Number -eq $number 
+            $NumberInfo = Get-ZoomPhoneNumbers -ErrorAction Stop | Where-object Number -eq $number 
 
             if (!($NumberInfo)) {
 

--- a/PSZoom/Public/Phone/Add-ZoomPhoneUserNumber.ps1
+++ b/PSZoom/Public/Phone/Add-ZoomPhoneUserNumber.ps1
@@ -1,0 +1,110 @@
+<#
+
+.SYNOPSIS
+Add an available phone number to a Zoom User.
+                    
+.PARAMETER Number
+Phone number to be assigned to zoom user.
+Use following command to get available phone numbers for Zoom instance.
+Get-ZoomPhoneNumbers
+
+.OUTPUTS
+No output. Can use Passthru switch to pass UserId to output.
+
+.EXAMPLE
+Add-ZoomPhoneUserNumber -UserId askywakler@thejedi.com -PhoneNumber +18011011101
+
+.EXAMPLE
+Add-ZoomPhoneUserNumber -UserId askywakler@thejedi.com -PhoneNumber 18011011101
+
+.LINK
+https://developers.zoom.us/docs/api/rest/reference/phone/methods/#operation/assignCallingPlan
+
+
+#>
+
+function Add-ZoomPhoneUserNumber {    
+    [CmdletBinding(SupportsShouldProcess = $True)]
+    Param(
+        [Parameter(
+            Mandatory = $True,       
+            ValueFromPipeline = $True,
+            ValueFromPipelineByPropertyName = $True,
+            Position = 0
+        )]
+        [ValidateLength(1, 128)]
+        [Alias('Email', 'Emails', 'EmailAddress', 'EmailAddresses', 'Id', 'ids', 'user_id', 'user', 'users', 'userids')]
+        [string[]]$UserId,
+
+        [Parameter(
+            Mandatory = $True, 
+            Position = 1
+        )]
+        [Alias('Phone_Number')]
+        [ValidateScript({(($_ -match "^\+[0-9]+$") -or ($_ -match "^[0-9]+$"))})]
+        [string]$Number,
+
+        [switch]$PassThru
+    )
+    
+
+
+    process {
+        foreach ($user in $UserId) {
+
+            if ($number -match "^[0-9]+") {
+
+                $number = "{0}$number" -f '+'
+
+            }
+
+            $NumberInfo = Get-ZoomPhoneNumbers | Where-object Number -eq $number 
+
+            if (!($NumberInfo)) {
+
+                Throw "Provided number was not found in the accounts's phone number list"
+
+            }
+
+            if ([bool]($NumberInfo.PSobject.Properties.name -match "assignee")) {
+
+                Throw "Number is already assigned to another user"
+
+            }
+
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/users/$user/phone_numbers"
+            $RequestBody = @{ }
+            $ChosenNumber = @{ }
+
+
+            $KeyValuePairs = @{
+                'id'      = $NumberInfo.id
+                'number'  = $NumberInfo.number
+            }
+
+            $KeyValuePairs.Keys | ForEach-Object {
+                if (-not ([string]::IsNullOrEmpty($KeyValuePairs.$_))) {
+                    $ChosenNumber.Add($_, $KeyValuePairs.$_)
+                }
+            }
+
+            $ChosenNumber = @($ChosenNumber)
+
+            $RequestBody.Add("phone_numbers", $ChosenNumber)
+
+            $RequestBody = $RequestBody | ConvertTo-Json
+
+            if ($pscmdlet.ShouldProcess) {
+                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $requestBody -Method POST
+        
+                if (-not $PassThru) {
+                    Write-Output $response
+                }
+            }
+        }
+
+        if ($PassThru) {
+            Write-Output $UserId
+        }
+    }
+}

--- a/PSZoom/Public/Phone/Get-ZoomPhoneCallingPlans.ps1
+++ b/PSZoom/Public/Phone/Get-ZoomPhoneCallingPlans.ps1
@@ -20,7 +20,7 @@ function Get-ZoomPhoneCallingPlans {
     param ()
 
     process {
-        $request = [System.UriBuilder]"https://api.zoom.us/v2/phone/calling_plans"        
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/calling_plans"        
         $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET
         
         Write-Output $response        

--- a/PSZoom/Public/Phone/Get-ZoomPhoneCallingPlans.ps1
+++ b/PSZoom/Public/Phone/Get-ZoomPhoneCallingPlans.ps1
@@ -21,7 +21,7 @@ function Get-ZoomPhoneCallingPlans {
 
     process {
         $request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/calling_plans"        
-        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET
+        $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET | Select-Object -ExpandProperty calling_plans
         
         Write-Output $response        
     }	

--- a/PSZoom/Public/Phone/Get-ZoomPhoneNumbers.ps1
+++ b/PSZoom/Public/Phone/Get-ZoomPhoneNumbers.ps1
@@ -1,0 +1,42 @@
+<#
+
+.SYNOPSIS
+List all Zoom Phone numbers that are associated with account Account.
+
+.DESCRIPTION
+List all Zoom Phone numbers that are associated with account Account.
+
+
+.LINK
+https://developers.zoom.us/docs/api/rest/reference/phone/methods/#operation/listAccountPhoneNumbers
+	
+.EXAMPLE
+Get-ZoomPhoneNumbers
+#>
+
+function Get-ZoomPhoneNumbers {
+
+    [CmdletBinding()]
+    param ()
+
+    process {
+        $page_size = '100'
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/numbers?page_size=$page_size"        
+        $QueryAmount = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET -ErrorAction Stop | Select-Object -ExpandProperty total_records
+        $TotalQueries = [math]::ceiling($QueryAmount/100)
+
+        do {
+
+            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET -ErrorAction Stop
+            $next_page_token = $response | Select-Object -ExpandProperty next_page_token
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/numbers?page_size=$page_size&next_page_token=$next_page_token"
+            $TotalQueries += -1
+            $AllNumbers += $response | Select-Object -ExpandProperty phone_numbers
+
+        } until ($TotalQueries -eq 0)
+
+        
+        
+        Write-Output $AllNumbers        
+    }	
+}

--- a/PSZoom/Public/Phone/Get-ZoomPhoneSettingTemplate.ps1
+++ b/PSZoom/Public/Phone/Get-ZoomPhoneSettingTemplate.ps1
@@ -37,7 +37,7 @@ function Get-ZoomPhoneSettingTemplate {
 
     process {
         foreach ($id in $TemplateId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/phone/setting_templates/$id"
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/setting_templates/$id"
 
             $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET
 

--- a/PSZoom/Public/Phone/Get-ZoomPhoneSettingTemplates.ps1
+++ b/PSZoom/Public/Phone/Get-ZoomPhoneSettingTemplates.ps1
@@ -60,7 +60,7 @@ function Get-ZoomPhoneSettingTemplates {
      )
 
     process {
-        $request = [System.UriBuilder]'https://api.zoom.us/v2/phone/setting_templates/'
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/setting_templates/"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
         $query.Add('page_size', $PageSize)
         $query.Add('page_number', $PageNumber)

--- a/PSZoom/Public/Phone/Get-ZoomPhoneUser.ps1
+++ b/PSZoom/Public/Phone/Get-ZoomPhoneUser.ps1
@@ -37,7 +37,8 @@ function Get-ZoomPhoneUser {
 
     process {
         foreach ($id in $UserId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/phone/users/$id"
+
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/users/$id"
 
             $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET
 

--- a/PSZoom/Public/Phone/Get-ZoomPhoneUserSettings.ps1
+++ b/PSZoom/Public/Phone/Get-ZoomPhoneUserSettings.ps1
@@ -36,7 +36,7 @@ function Get-ZoomPhoneUserSettings {
 
     process {
         foreach ($id in $UserId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/phone/users/$id/settings"
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/users/$id/settings"
 
             $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET
 

--- a/PSZoom/Public/Phone/Get-ZoomPhoneUsers.ps1
+++ b/PSZoom/Public/Phone/Get-ZoomPhoneUsers.ps1
@@ -61,7 +61,7 @@ function Get-ZoomPhoneUsers {
      )
 
     process {
-        $request = [System.UriBuilder]'https://api.zoom.us/v2/phone/users'
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/users"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
         $query.Add('page_size', $PageSize)
         $query.Add('next_page_token', $NextPageToken)

--- a/PSZoom/Public/Phone/Remove-ZoomPhoneUserCallingPlans.ps1
+++ b/PSZoom/Public/Phone/Remove-ZoomPhoneUserCallingPlans.ps1
@@ -1,0 +1,55 @@
+<#
+
+.SYNOPSIS
+Remove calling plan to a Zoom Phone User
+
+.OUTPUTS
+No output. Can use Passthru switch to pass UserId to output.
+
+.EXAMPLE
+Remove-ZoomPhoneUserCallingPlans -UserId askywakler@thejedi.com
+
+.LINK
+https://developers.zoom.us/docs/api/rest/reference/phone/methods/#operation/unassignCallingPlan
+
+#>
+
+function Remove-ZoomPhoneUserCallingPlans {    
+    [CmdletBinding(SupportsShouldProcess = $True)]
+    Param(
+        [Parameter(
+            Mandatory = $True,       
+            ValueFromPipeline = $True,
+            ValueFromPipelineByPropertyName = $True,
+            Position = 0
+        )]
+        [ValidateLength(1, 128)]
+        [Alias('Email', 'Emails', 'EmailAddress', 'EmailAddresses', 'Id', 'ids', 'user_id', 'user', 'users', 'userids')]
+        [string[]]$UserId,
+
+        [switch]$PassThru
+    )
+    
+
+
+    process {
+        foreach ($user in $UserId) {
+
+            $CurrentLicense = Get-ZoomPhoneUser -UserId $user | Select-Object -ExpandProperty "calling_plans" | Select-Object -ExpandProperty "type"
+
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/users/$user/calling_plans/$CurrentLicense"
+
+            if ($pscmdlet.ShouldProcess) {
+                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method Delete
+        
+                if (-not $PassThru) {
+                    Write-Output $response
+                }
+            }
+        }
+
+        if ($PassThru) {
+            Write-Output $UserId
+        }
+    }
+}

--- a/PSZoom/Public/Phone/Remove-ZoomPhoneUserNumber.ps1
+++ b/PSZoom/Public/Phone/Remove-ZoomPhoneUserNumber.ps1
@@ -1,0 +1,120 @@
+<#
+
+.SYNOPSIS
+Remove phone numbers from a user's zoom phone account.
+                    
+.PARAMETER Number
+Specific phone number to be unassigned from zoom user.
+Use following command to get a list of phone numbers assigned to a user.
+Get-ZoomPhoneUser
+
+.PARAMETER AllNumbers
+Removes all phones numbers assigned to zoom user.
+
+.OUTPUTS
+No output. Can use Passthru switch to pass UserId to output.
+
+.EXAMPLE
+Remove-ZoomPhoneUserNumber -UserId askywakler@thejedi.com -PhoneNumber +18011011101
+
+.EXAMPLE
+Remove-ZoomPhoneUserNumber -UserId askywakler@thejedi.com -PhoneNumber 18011011101
+
+.EXAMPLE
+Remove-ZoomPhoneUserNumber -UserId askywakler@thejedi.com -AllNumbers
+
+.LINK
+https://developers.zoom.us/docs/api/rest/reference/phone/methods/#operation/UnassignPhoneNumber
+
+
+#>
+
+function Remove-ZoomPhoneUserNumber {    
+    [CmdletBinding(
+        SupportsShouldProcess = $True,
+        DefaultParameterSetName="SingleNumber"
+    )]
+    Param(
+        # -UserID
+        [parameter(ParameterSetName="SingleNumber")]
+        [parameter(ParameterSetName="AllNumbers")]
+        [Parameter(
+            Mandatory = $True,       
+            ValueFromPipeline = $True,
+            ValueFromPipelineByPropertyName = $True,
+            Position = 0
+        )]
+        [ValidateLength(1, 128)]
+        [Alias('Email', 'Emails', 'EmailAddress', 'EmailAddresses', 'Id', 'ids', 'user_id', 'user', 'users', 'userids')]
+        [string[]]$UserId,
+
+
+        # -Number
+        [parameter(ParameterSetName="SingleNumber",
+            Mandatory = $True, 
+            Position = 1
+        )]
+        [Alias('Phone_Number')]
+        [ValidateScript({(($_ -match "^\+[0-9]+$") -or ($_ -match "^[0-9]+$"))})]
+        [string]$Number,
+
+
+        # -AllNumbers
+        [parameter(ParameterSetName="AllNumbers")]
+        [switch]$AllNumbers,
+
+
+        # -Passthru
+        [parameter(ParameterSetName="SingleNumber")]
+        [parameter(ParameterSetName="AllNumbers")]
+        [switch]$PassThru
+    )
+    
+
+
+    process {
+        foreach ($user in $UserId) {
+
+            $ZoomUserInfo = Get-ZoomPhoneUser -UserId $user -ErrorAction Stop
+
+            $VerifiedNumbersToBeRemoved = $ZoomUserInfo | Select-Object -ExpandProperty phone_numbers
+            
+            if ($number) {
+
+                if ($number -match "^[0-9]+") {
+
+                    $number = "{0}$number" -f '+'
+    
+                }
+
+                $VerifiedNumbersToBeRemoved = $ZoomUserInfo | Select-Object -ExpandProperty phone_numbers | Where-Object number -eq $number
+
+                if ([string]::IsNullOrEmpty($VerifiedNumbersToBeRemoved)) {
+                
+                    throw "The number provided is not assigned to user! Number: $number"
+    
+                }
+
+            }
+
+            $VerifiedNumbersToBeRemoved | ForEach-Object {
+
+                $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/users/$user/phone_numbers/$($_.id)"
+
+                if ($pscmdlet.ShouldProcess) {
+                    $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method DELETE
+            
+                    if (-not $PassThru) {
+                        Write-Output $response
+                    }
+                }
+
+            }
+
+        }
+
+        if ($PassThru) {
+            Write-Output $UserId
+        }
+    }
+}

--- a/PSZoom/Public/Phone/Update-ZoomPhoneUserCallingPlans.ps1
+++ b/PSZoom/Public/Phone/Update-ZoomPhoneUserCallingPlans.ps1
@@ -1,0 +1,86 @@
+<#
+
+.SYNOPSIS
+Alter calling plan on a Zoom Phone User
+                    
+.PARAMETER LicenseType
+License Type that is to applied to target phone account.
+Use following command to get available license types for Zoom instance.
+Get-ZoomPhoneCallingPlans
+
+.OUTPUTS
+No output. Can use Passthru switch to pass UserId to output.
+
+.EXAMPLE
+Update-ZoomPhoneUserCallingPlans -UserId askywakler@thejedi.com -Type 200
+
+.LINK
+https://developers.zoom.us/docs/api/rest/reference/phone/methods/#operation/updateCallingPlan
+
+.LINK
+https://developers.zoom.us/docs/api/rest/other-references/plans/
+
+#>
+
+function Update-ZoomPhoneUserCallingPlans {    
+    [CmdletBinding(SupportsShouldProcess = $True)]
+    Param(
+        [Parameter(
+            Mandatory = $True,       
+            ValueFromPipeline = $True,
+            ValueFromPipelineByPropertyName = $True,
+            Position = 0
+        )]
+        [ValidateLength(1, 128)]
+        [Alias('Email', 'Emails', 'EmailAddress', 'EmailAddresses', 'Id', 'ids', 'user_id', 'user', 'users', 'userids')]
+        [string[]]$UserId,
+
+        [Parameter(
+            Mandatory = $True, 
+            Position = 1
+        )]
+        [Alias('License_Type')]
+        [int]$LicenseType,
+
+        [switch]$PassThru
+    )
+    
+
+
+    process {
+        foreach ($user in $UserId) {
+
+            $CurrentLicense = Get-ZoomPhoneUser -UserId $user | Select-Object -ExpandProperty "calling_plans" | Select-Object -ExpandProperty "type"
+
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/users/$user/calling_plans"
+            $RequestBody = @{ }
+
+
+            $KeyValuePairs = @{
+                'source_type'    = $CurrentLicense
+                'target_type'    = $LicenseType
+
+            }
+
+            $KeyValuePairs.Keys | ForEach-Object {
+                if (-not ([string]::IsNullOrEmpty($KeyValuePairs.$_))) {
+                    $RequestBody.Add($_, $KeyValuePairs.$_)
+                }
+            }
+
+            $RequestBody = $RequestBody | ConvertTo-Json
+
+            if ($pscmdlet.ShouldProcess) {
+                $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $requestBody -Method POST
+        
+                if (-not $PassThru) {
+                    Write-Output $response
+                }
+            }
+        }
+
+        if ($PassThru) {
+            Write-Output $UserId
+        }
+    }
+}

--- a/PSZoom/Public/PhoneSite/Get-ZoomPhoneSite.ps1
+++ b/PSZoom/Public/PhoneSite/Get-ZoomPhoneSite.ps1
@@ -36,7 +36,7 @@ function Get-ZoomPhoneSite {
 
     process {
         foreach ($id in $SiteId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/phone/sites/$id"
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/sites/$id"
 
             $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET
 

--- a/PSZoom/Public/PhoneSite/Get-ZoomPhoneSites.ps1
+++ b/PSZoom/Public/PhoneSite/Get-ZoomPhoneSites.ps1
@@ -67,7 +67,7 @@ function Get-ZoomPhoneSites {
     )
 
     process {
-        $request = [System.UriBuilder]"https://api.zoom.us/v2/phone/sites"
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/sites"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
         $query.Add('page_size', $PageSize)
         if ($NextPageToken) {

--- a/PSZoom/Public/Reports/Get-ZoomActiveInactiveHostReports.ps1
+++ b/PSZoom/Public/Reports/Get-ZoomActiveInactiveHostReports.ps1
@@ -122,7 +122,7 @@ function Get-ZoomActiveInactiveHostReports {
 
     process {
         if ($PsCmdlet.ParameterSetName -eq 'Default') {
-            $Request = [System.UriBuilder]"https://api.zoom.us/v2/report/users"
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/report/users"
             $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)  
             $query.Add('from', $From)
             $query.Add('to', $To)

--- a/PSZoom/Public/Reports/Get-ZoomCloudRecordingReport.ps1
+++ b/PSZoom/Public/Reports/Get-ZoomCloudRecordingReport.ps1
@@ -43,7 +43,7 @@ function Get-ZoomCloudRecordingReport {
      )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/report/cloud_recording"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/report/cloud_recording"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
 
         if ($PSBoundParameters.ContainsKey('From')) {

--- a/PSZoom/Public/Reports/Get-ZoomDailyUsageReport.ps1
+++ b/PSZoom/Public/Reports/Get-ZoomDailyUsageReport.ps1
@@ -39,7 +39,7 @@ function Get-ZoomDailyUsageReport {
     )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/report/daily"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/report/daily"
 
         if ($Year -or $Query) {
             $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)  

--- a/PSZoom/Public/Reports/Get-ZoomMeetingParticipantsReport.ps1
+++ b/PSZoom/Public/Reports/Get-ZoomMeetingParticipantsReport.ps1
@@ -70,7 +70,7 @@ function Get-ZoomMeetingParticipantsReport {
     process {
         if ($PsCmdlet.ParameterSetName -eq 'Default') {
             foreach ($id in $MeetingId) {
-                $Request = [System.UriBuilder]"https://api.zoom.us/v2/report/meetings/$MeetingId/participants"
+                $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/report/meetings/$MeetingId/participants"
                 $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)  
                 $query.Add('page_size', $PageSize)
                 $query.Add('next_page_token', $NextPageToken)

--- a/PSZoom/Public/Reports/Get-ZoomTelephoneReports.ps1
+++ b/PSZoom/Public/Reports/Get-ZoomTelephoneReports.ps1
@@ -118,7 +118,7 @@ function Get-ZoomTelephoneReports {
     
                 Write-Output $CombinedReport
         } else {
-            $Request = [System.UriBuilder]"https://api.zoom.us/v2/report/telephone"
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/report/telephone"
             $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)  
             $query.Add('type', $Type)
             $query.Add('from', $From)

--- a/PSZoom/Public/Reports/Get-ZoomWebinarDetailsReport.ps1
+++ b/PSZoom/Public/Reports/Get-ZoomWebinarDetailsReport.ps1
@@ -32,7 +32,7 @@ function Get-ZoomWebinarDetailsReport {
 
     process {
         foreach ($id in $WebinarId) {
-            $Request = [System.UriBuilder]"https://api.zoom.us/v2/report/webinars/$WebinarId"
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/report/webinars/$WebinarId"
 
             $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET
             

--- a/PSZoom/Public/Reports/Get-ZoomWebinarParticipantsReport.ps1
+++ b/PSZoom/Public/Reports/Get-ZoomWebinarParticipantsReport.ps1
@@ -48,7 +48,7 @@ function Get-ZoomWebinarParticipantsReport {
 
     process {
         foreach ($id in $WebinarId) {
-            $Request = [System.UriBuilder]"https://api.zoom.us/v2/report/webinars/$WebinarId/participants"
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/report/webinars/$WebinarId/participants"
             $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)  
             $query.Add('page_size', $PageSize)
 

--- a/PSZoom/Public/Rooms/Connect-ZoomRoomMeeting.ps1
+++ b/PSZoom/Public/Rooms/Connect-ZoomRoomMeeting.ps1
@@ -97,7 +97,7 @@ function Connect-ZoomRoomMeeting {
 
     process {
         foreach ($id in $RoomId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/rooms/$id/meetings"  
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/rooms/$id/meetings"  
 
             $requestBody = @{
                 'jsonrpc' = $JsonRpc

--- a/PSZoom/Public/Rooms/Disconnect-ZoomRoomMeeting.ps1
+++ b/PSZoom/Public/Rooms/Disconnect-ZoomRoomMeeting.ps1
@@ -54,7 +54,7 @@ function Disconnect-ZoomRoomMeeting {
 
     process {
         foreach ($id in $RoomId) {
-            $Request = [System.UriBuilder]"https://api.zoom.us/v2/rooms/$id/meetings"  
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/rooms/$id/meetings"  
 
             $requestBody = @{
                 'jsonrpc' = $JsonRpc

--- a/PSZoom/Public/Rooms/Get-ZoomRoomDevices.ps1
+++ b/PSZoom/Public/Rooms/Get-ZoomRoomDevices.ps1
@@ -47,7 +47,7 @@ function Get-ZoomRoomDevices {
      )
 
     process {
-        $request = [System.UriBuilder]"https://api.zoom.us/v2/rooms/$($RoomID)/devices"
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/rooms/$($RoomID)/devices"
 
         try {
             $response = Invoke-ZoomRestMethod -Uri $request.Uri -Headers $headers -Method GET

--- a/PSZoom/Public/Rooms/Get-ZoomRoomLocations.ps1
+++ b/PSZoom/Public/Rooms/Get-ZoomRoomLocations.ps1
@@ -70,7 +70,7 @@ function Get-ZoomRoomLocations {
      ) 
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/rooms/locations"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/rooms/locations"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
         $query.Add('page_size', $PageSize)
 

--- a/PSZoom/Public/Rooms/Get-ZoomRooms.ps1
+++ b/PSZoom/Public/Rooms/Get-ZoomRooms.ps1
@@ -113,7 +113,7 @@ function Get-ZoomRooms {
      )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/rooms"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/rooms"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
         $query.Add('page_size', $PageSize)
         $query.Add('unassigned_rooms', $unassigned_rooms)

--- a/PSZoom/Public/Rooms/Get-ZoomRoomsDashboard.ps1
+++ b/PSZoom/Public/Rooms/Get-ZoomRoomsDashboard.ps1
@@ -85,7 +85,7 @@ function Get-ZoomRoomsDashboard {
      )
 
     process {
-        $request = [System.UriBuilder]"https://api.zoom.us/v2/metrics/zoomrooms"
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/metrics/zoomrooms"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
         $query.Add('page_size', $PageSize)
 

--- a/PSZoom/Public/Rooms/New-ZoomRoomInvite.ps1
+++ b/PSZoom/Public/Rooms/New-ZoomRoomInvite.ps1
@@ -71,7 +71,7 @@ function New-ZoomRoomInvite {
      )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/rooms/$RoomId/zrclient"  
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/rooms/$RoomId/zrclient"  
 
         $requestBody = @{
             'jsonrpc' = $JsonRpc

--- a/PSZoom/Public/Rooms/New-ZoomRoomMeeting.ps1
+++ b/PSZoom/Public/Rooms/New-ZoomRoomMeeting.ps1
@@ -110,7 +110,7 @@ function New-ZoomRoomMeeting {
 
     process {
         foreach ($id in $RoomId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/rooms/$id/meetings"  
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/rooms/$id/meetings"  
 
             $requestBody = @{
                 'jsonrpc' = $JsonRpc

--- a/PSZoom/Public/Rooms/Remove-ZoomRoomMeeting.ps1
+++ b/PSZoom/Public/Rooms/Remove-ZoomRoomMeeting.ps1
@@ -117,7 +117,7 @@ function Remove-ZoomRoomMeeting {
 
     process {
         foreach ($Number in $MeetingNumber) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/rooms/$RoomId/meetings"  
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/rooms/$RoomId/meetings"  
 
             $requestBody = @{
                 'jsonrpc'        = $JsonRpc

--- a/PSZoom/Public/Rooms/Restart-ZoomRoom.ps1
+++ b/PSZoom/Public/Rooms/Restart-ZoomRoom.ps1
@@ -57,7 +57,7 @@ function Restart-ZoomRoom {
 
     process {
         foreach ($id in $RoomId) {
-            $Request = [System.UriBuilder]"https://api.zoom.us/v2/rooms/$id/zrclient"  
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/rooms/$id/zrclient"  
 
             $requestBody = @{
                 'jsonrpc' = $JsonRpc

--- a/PSZoom/Public/Rooms/Stop-ZoomRoomMeeting.ps1
+++ b/PSZoom/Public/Rooms/Stop-ZoomRoomMeeting.ps1
@@ -55,7 +55,7 @@ function Stop-ZoomRoomMeeting {
 
     process {
         foreach ($id in $RoomId) {
-            $Request = [System.UriBuilder]"https://api.zoom.us/v2/rooms/$id/meetings"  
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/rooms/$id/meetings"  
 
             $requestBody = @{
                 'jsonrpc' = $JsonRpc

--- a/PSZoom/Public/Users/Add-ZoomUserAssistants.ps1
+++ b/PSZoom/Public/Users/Add-ZoomUserAssistants.ps1
@@ -60,7 +60,7 @@ function Add-ZoomUserAssistants {
 
     process {
         foreach ($Id in $UserId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/users/$Id/assistants"
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$Id/assistants"
 
             $assistants = @()
     

--- a/PSZoom/Public/Users/Get-ZoomPersonalMeetingRoomName.ps1
+++ b/PSZoom/Public/Users/Get-ZoomPersonalMeetingRoomName.ps1
@@ -35,7 +35,7 @@ function Get-ZoomPersonalMeetingRoomName {
 
     process {
         foreach ($name in $VanityName) {
-            $Request = [System.UriBuilder]"https://api.zoom.us/v2/users/vanity_name"
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/vanity_name"
     
             $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)  
             $query.Add('vanity_name', $VanityName)

--- a/PSZoom/Public/Users/Get-ZoomUser.ps1
+++ b/PSZoom/Public/Users/Get-ZoomUser.ps1
@@ -69,7 +69,7 @@ function Get-ZoomUser {
 
     process {
         foreach ($id in $UserId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/users/$id"
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$id"
             $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
 
             if ($PSBoundParameters.ContainsKey('EncryptedEmail')) {

--- a/PSZoom/Public/Users/Get-ZoomUserAssistants.ps1
+++ b/PSZoom/Public/Users/Get-ZoomUserAssistants.ps1
@@ -32,7 +32,7 @@ function Get-ZoomUserAssistants {
 
     process {
         foreach ($id in $UserId) {
-            $Request = [System.UriBuilder]"https://api.zoom.us/v2/users/$Id/assistants"
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$Id/assistants"
 
            $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET
     

--- a/PSZoom/Public/Users/Get-ZoomUserEmailStatus.ps1
+++ b/PSZoom/Public/Users/Get-ZoomUserEmailStatus.ps1
@@ -33,7 +33,7 @@ function Get-ZoomUserEmailStatus {
      )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/users/email"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/email"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
         $query.Add('email', $Email)
         $Request.Query = $query.ToString()

--- a/PSZoom/Public/Users/Get-ZoomUserPermissions.ps1
+++ b/PSZoom/Public/Users/Get-ZoomUserPermissions.ps1
@@ -34,7 +34,7 @@ function Get-ZoomUserPermissions {
      )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/users/$UserId/permissions"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$UserId/permissions"
         $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET
 
         Write-Output $response

--- a/PSZoom/Public/Users/Get-ZoomUserSchedulers.ps1
+++ b/PSZoom/Public/Users/Get-ZoomUserSchedulers.ps1
@@ -34,7 +34,7 @@ function Get-ZoomUserSchedulers {
     )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/users/$UserId/schedulers"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$UserId/schedulers"
         $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method GET
 
         Write-Output $response

--- a/PSZoom/Public/Users/Get-ZoomUserSettings.ps1
+++ b/PSZoom/Public/Users/Get-ZoomUserSettings.ps1
@@ -57,7 +57,7 @@ function Get-ZoomUserSettings {
      )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/users/$UserId/settings"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$UserId/settings"
 
         if ($PSBoundParameters.ContainsKey('LoginType')) {
             $LoginType = ConvertTo-LoginTypeCode -Code $LoginType

--- a/PSZoom/Public/Users/Get-ZoomUserToken.ps1
+++ b/PSZoom/Public/Users/Get-ZoomUserToken.ps1
@@ -43,7 +43,7 @@ function Get-ZoomUserToken {
      )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/users/$UserId/token"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$UserId/token"
 
         if ($PSBoundParameters.ContainsKey('Type')) {
             $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)  

--- a/PSZoom/Public/Users/Get-ZoomUsers.ps1
+++ b/PSZoom/Public/Users/Get-ZoomUsers.ps1
@@ -130,7 +130,7 @@ function Get-ZoomUsers {
      )
 
     process {
-        $Request = [System.UriBuilder]'https://api.zoom.us/v2/users/'
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
         $query.Add('status', $Status)
         $query.Add('page_size', $PageSize)

--- a/PSZoom/Public/Users/New-ZoomUser.ps1
+++ b/PSZoom/Public/Users/New-ZoomUser.ps1
@@ -88,7 +88,7 @@ function New-ZoomUser {
     )
     
     process {
-        $request = [System.UriBuilder]'https://api.zoom.us/v2/users'
+        $request = [System.UriBuilder]'https://api.$ZoomURI/v2/users'
 
         #Request Body
         $requestBody = @{

--- a/PSZoom/Public/Users/Remove-ZoomSpecificUserAssistant.ps1
+++ b/PSZoom/Public/Users/Remove-ZoomSpecificUserAssistant.ps1
@@ -44,7 +44,7 @@ function Remove-ZoomSpecificUserAssistant {
     process {
         foreach ($id in $UserId) {
             foreach ($aid in $AssistantId) {
-                $request = [System.UriBuilder]"https://api.zoom.us/v2/users/$id/assistants/$aid"
+                $request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$id/assistants/$aid"
                 $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method DELETE
 
                 Write-Output $response

--- a/PSZoom/Public/Users/Remove-ZoomSpecificUserScheduler.ps1
+++ b/PSZoom/Public/Users/Remove-ZoomSpecificUserScheduler.ps1
@@ -50,7 +50,7 @@ function Remove-ZoomSpecificUserScheduler {
         foreach ($user in $UserId) {
             foreach ($scheduler in $schedulerId) {
                 if ($PScmdlet.ShouldProcess($user, "Remove $scheduler")) {
-                    $request = [System.UriBuilder]"https://api.zoom.us/v2/users/$user/schedulers/$scheduler"
+                    $request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$user/schedulers/$scheduler"
                     
                     Invoke-ZoomRestMethod -Uri $request.Uri -Method DELETE
 

--- a/PSZoom/Public/Users/Remove-ZoomUser.ps1
+++ b/PSZoom/Public/Users/Remove-ZoomUser.ps1
@@ -86,7 +86,7 @@ function Remove-ZoomUser {
 
     process {
         foreach ($user in $UserId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/users/$user"
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$user"
             $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
             $query.Add('action', $Action)
 

--- a/PSZoom/Public/Users/Remove-ZoomUserAssistants.ps1
+++ b/PSZoom/Public/Users/Remove-ZoomUserAssistants.ps1
@@ -37,7 +37,7 @@ function Remove-ZoomUserAssistants {
 
     process {
         foreach ($user in $UserId) {
-            $Request = [System.UriBuilder]"https://api.zoom.us/v2/users/$user/assistants"
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$user/assistants"
     
             Invoke-ZoomRestMethod -Uri $request.Uri -Method DELETE
  

--- a/PSZoom/Public/Users/Remove-ZoomUserSchedulers.ps1
+++ b/PSZoom/Public/Users/Remove-ZoomUserSchedulers.ps1
@@ -37,7 +37,7 @@ function Remove-ZoomUserSchedulers {
 
     process {
         foreach ($user in $UserId) {
-            $Request = [System.UriBuilder]"https://api.zoom.us/v2/users/$user/schedulers"
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$user/schedulers"
     
             Invoke-ZoomRestMethod -Uri $request.Uri -Method DELETE
 

--- a/PSZoom/Public/Users/Revoke-ZoomUserSsoToken.ps1
+++ b/PSZoom/Public/Users/Revoke-ZoomUserSsoToken.ps1
@@ -37,7 +37,7 @@ function Revoke-ZoomUserSsoToken {
 
     process {
         foreach ($user in $UserId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/users/$user/token"
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$user/token"
             $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method DELETE
 
             if ($Passthru) {

--- a/PSZoom/Public/Users/Update-ZoomProfilePicture.ps1
+++ b/PSZoom/Public/Users/Update-ZoomProfilePicture.ps1
@@ -41,7 +41,7 @@ function Update-ZoomProfilePicture {
 
     process {
         foreach ($user in $UserId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/users/$user/picture"
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$user/picture"
             $LF = "`r`n";
 
             if ($PSVersionTable.PSVersion.Major -lt 6) {

--- a/PSZoom/Public/Users/Update-ZoomUser.ps1
+++ b/PSZoom/Public/Users/Update-ZoomUser.ps1
@@ -182,7 +182,7 @@ function Update-ZoomUser {
 
     process {
         foreach ($user in $UserId) {
-            $Request = [System.UriBuilder]"https://api.zoom.us/v2/users/$user"
+            $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$user"
             $RequestBody = @{ }   
 
             if ($PSBoundParameters.ContainsKey('LoginType')) {

--- a/PSZoom/Public/Users/Update-ZoomUserEmail.ps1
+++ b/PSZoom/Public/Users/Update-ZoomUserEmail.ps1
@@ -47,7 +47,7 @@ function Update-ZoomUserEmail {
     )
 
     process {
-        $request = [System.UriBuilder]"https://api.zoom.us/v2/users/$UserId/email"
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$UserId/email"
 
         $requestBody = @{
             'email' = $Email

--- a/PSZoom/Public/Users/Update-ZoomUserPassword.ps1
+++ b/PSZoom/Public/Users/Update-ZoomUserPassword.ps1
@@ -51,7 +51,7 @@ function Update-ZoomUserpassword {
 
     process {
         foreach ($user in $UserId){
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/users/$user/password"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$user/password"
             $requestBody = @{
                 'password' = $Password
             }

--- a/PSZoom/Public/Users/Update-ZoomUserSettings.ps1
+++ b/PSZoom/Public/Users/Update-ZoomUserSettings.ps1
@@ -802,7 +802,7 @@ function Update-ZoomUserSettings {
 
     process {
         foreach ($user in $UserId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/users/$user/settings"
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$user/settings"
 
             $scheduleMeeting = @{
                 'host_video'                                  = 'HostVideo'

--- a/PSZoom/Public/Users/Update-ZoomUserStatus.ps1
+++ b/PSZoom/Public/Users/Update-ZoomUserStatus.ps1
@@ -51,7 +51,7 @@ function Update-ZoomUserStatus {
 
     process {
         foreach ($user in $UserId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/users/$user/status"
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$user/status"
             $requestBody = @{
                 'action' = $Action.ToLower()
             }

--- a/PSZoom/Public/Utils/Connect-PSZoom.ps1
+++ b/PSZoom/Public/Utils/Connect-PSZoom.ps1
@@ -5,8 +5,25 @@ Use this cmdlet to retrieve a token from Zoom.
 .DESCRIPTION
 Assigns a token to the variable $Script:PSZoomToken which is used by all cmdlets when making requests to Zoom.
 
+.PARAMETER ClientID
+Client ID of the Zoom App
+
+.PARAMETER ClientSecret
+Client Secret of the Zoom App
+
+.PARAMETER AccountID
+Account ID of the Zoom App
+
+.PARAMETER APIConnection
+Zoom environment for specified AccountID
+- Zoom.us
+- Zoomgov.com
+
 .EXAMPLE
 Connect-PSZoom -AccountID 'your_account_id' -ClientID 'your_client_id' -ClientSecret 'your_client_secret'
+
+.EXAMPLE
+Connect-PSZoom -AccountID 'your_account_id' -ClientID 'your_client_id' -ClientSecret 'your_client_secret' -$APIConnection 'Zoom.us'
 
 #>
 
@@ -31,10 +48,18 @@ function Connect-PSZoom {
             Mandatory = $True, 
             Position = 2
         )]
-        [string]$ClientSecret
+        [string]$ClientSecret,
+
+        [Alias('SiteConnection')]
+        [Parameter(
+            Mandatory = $False
+        )]
+        [ValidateSet("Zoom.Us","Zoomgov.com")]
+        [string]$APIConnection = "Zoom.us"
     )
 
     try {
+        $Script:ZoomURI = $APIConnection
         $token = New-OAuthToken -AccountID $AccountID -ClientID $ClientID -ClientSecret $ClientSecret
         $Script:PSZoomToken = $token
     } catch {

--- a/PSZoom/Public/Utils/New-OAuthToken.ps1
+++ b/PSZoom/Public/Utils/New-OAuthToken.ps1
@@ -56,7 +56,7 @@ function New-OAuthToken {
 
     )
 
-    $uri = "https://zoom.us/oauth/token?grant_type=account_credentials&account_id={0}" -f $AccountID
+    $uri = "https://{1}/oauth/token?grant_type=account_credentials&account_id={0}" -f $AccountID, $ZoomURI
 
     #Encoding of the client data
     $IDSecret = $ClientID + ":" + $ClientSecret 

--- a/PSZoom/Public/Webinars/Get-ZoomWebinar.ps1
+++ b/PSZoom/Public/Webinars/Get-ZoomWebinar.ps1
@@ -53,7 +53,7 @@ function Get-ZoomWebinar {
     )
 
     process {
-        $Request = [System.UriBuilder]"https://api.zoom.us/v2/webinars/$webinarId"
+        $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/webinars/$webinarId"
         $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
         
 

--- a/PSZoom/Public/Webinars/Get-ZoomWebinarPanelists.ps1
+++ b/PSZoom/Public/Webinars/Get-ZoomWebinarPanelists.ps1
@@ -38,7 +38,7 @@ function Get-ZoomWebinarPanelists {
     )
 
     process {
-        $request = [System.UriBuilder]"https://api.zoom.us/v2/webinars/$webinarId/panelists"
+        $request = [System.UriBuilder]"https://api.$ZoomURI/v2/webinars/$webinarId/panelists"
         $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $RequestBody -Method GET
 
         Write-Output $response

--- a/PSZoom/Public/Webinars/Get-ZoomWebinarsFromUser.ps1
+++ b/PSZoom/Public/Webinars/Get-ZoomWebinarsFromUser.ps1
@@ -58,7 +58,7 @@ function Get-ZoomWebinarsFromUser {
 
     process {
         foreach ($id in $UserId) {
-            $request = [System.UriBuilder]"https://api.zoom.us/v2/users/$id/webinars"
+            $request = [System.UriBuilder]"https://api.$ZoomURI/v2/users/$id/webinars"
             $query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)  
             $query.Add('page_size', $PageSize)
             $query.Add('page_number', $PageNumber)

--- a/README.md
+++ b/README.md
@@ -103,12 +103,18 @@ Update-ZoomMeetingRegistrationQuestions
 Update-ZoomMeetingStatus  
   
 ## Phones ##  
-Get-ZoomPhoneCallingPlans  
+Add-ZoomPhoneUserCallingPlans
+Add-ZoomPhoneUserNumber
+Get-ZoomPhoneCallingPlans
+Get-ZoomPhoneNumbers  
 Get-ZoomPhoneSettingTemplate  
 Get-ZoomPhoneSettingTemplates  
 Get-ZoomPhoneUser  
 Get-ZoomPhoneUsers  
-Get-ZoomPhoneUserSettings  
+Get-ZoomPhoneUserSettings
+Remove-ZoomPhoneUserCallingPlans
+Remove-ZoomPhoneUserNumber
+Update-ZoomPhoneUserCallingPlans  
 
 ## Phone Sites ##  
 Get-ZoomPhoneSite  


### PR DESCRIPTION
Added support to select which zoom API URL is declared when establishing Zoom connection.  Default 'zoom.us'
```Powershell
Connect-PSZoom -APIConnection 'zoomgov.com'
```

Added new Zoom Phone functions.
```Powershell
# Calling Plans
Add-ZoomPhoneUserCallingPlans
Update-ZoomPhoneUserCallingPlans
Remove-ZoomPhoneUserCallingPlans

# User Phone Numbers
Add-ZoomPhoneUserNumber
Remove-ZoomPhoneUserNumber

# All Phone Numbers
Get-ZoomPhoneNumbers
```
