### PR TITLE
Fix Issue #95 - Adds ParticipantVideo option to New-ZoomMeeting and Update-ZoomMeeting cmdlets

### DIFF
--- a/PSZoom/Public/Meetings/New-ZoomMeeting.ps1
+++ b/PSZoom/Public/Meetings/New-ZoomMeeting.ps1
@@ -557,6 +557,10 @@ function New-ZoomMeeting {
         [Parameter(ValueFromPipelineByPropertyName = $True)]
         [Alias('host_video')]
         [bool]$HostVideo,
+
+        [Parameter(ValueFromPipelineByPropertyName = $True)]
+        [Alias('participant_video')]
+        [bool]$ParticipantVideo,
       
         [Parameter(ValueFromPipelineByPropertyName = $True)]
         [Alias('cn_meeting')]
@@ -844,6 +848,7 @@ function New-ZoomMeeting {
             'enforce_login_domains'          = 'EnforceLoginDomains'
             'global_dialin_countries'        = 'GlobalDialInCountries'
             'host_video'                     = 'HostVideo'
+            'participant_video'              = 'ParticipantVideo'
             'in_meeting'                     = 'INMeeting'
             'join_before_host'               = 'JoinBeforeHost'
             'mute_upon_entry'                = 'Mutentry'

--- a/PSZoom/Public/Meetings/Update-ZoomMeeting.ps1
+++ b/PSZoom/Public/Meetings/Update-ZoomMeeting.ps1
@@ -247,6 +247,10 @@ function Update-ZoomMeeting {
     [Parameter(ValueFromPipelineByPropertyName = $True)]
     [Alias('host_video')]
     [bool]$HostVideo,
+
+    [Parameter(ValueFromPipelineByPropertyName = $True)]
+    [Alias('participant_video')]
+    [bool]$ParticipantVideo,
     
     [Parameter(ValueFromPipelineByPropertyName = $True)]
     [Alias('cn_meeting')]
@@ -482,6 +486,7 @@ function Update-ZoomMeeting {
 
     $Settings = @{
         'host_video'              = 'HostVideo'
+        'participant_video'       = 'ParticipantVideo'
         'cn_meeting'              = 'CNMeeting'
         'in_meeting'              = 'INMeeting'
         'join_before_host'        = 'JoinBeforeHost'


### PR DESCRIPTION
I opened Issue #95 last year because I was having issues setting the ParticipantVideo option. At the time, it was mentioned that it's not supported despite the documentation.

Revisiting the issue, when I added the parameter manually, it does seem to be passed to the Zoom API and reflected in the meeting settings.

'HostVideo' only:
![image](https://github.com/JosephMcEvoy/PSZoom/assets/55399772/f3108be6-5d16-4d3a-80dc-5db321990479)

With 'ParticipantVideo' added:
![image](https://github.com/JosephMcEvoy/PSZoom/assets/55399772/60201999-b350-4647-995b-1f8ad68bbf99)

I'm hoping it's a straightforward addition, perhaps Zoom fixed something on the API end in the meantime.