### PR TITLE
ZoomPhone fixes

### DIFF
--- a/PSZoom/Public/Phone/CommonPhone/Add-ZoomPhoneCommonAreaCallingPlan.ps1
+++ b/PSZoom/Public/Phone/CommonPhone/Add-ZoomPhoneCommonAreaCallingPlan.ps1
@@ -53,6 +53,7 @@ function Add-ZoomPhoneCommonAreaCallingPlan {
             $RequestBody = @{ }
             $ChosenLicense = @{ }
 
+            $ZoomCommonAreaInfo = Get-ZoomPhoneCommonArea -CommonAreaId $_ -ErrorAction Stop
 
             $KeyValuePairs = @{
                 'type'    = $LicenseType
@@ -79,7 +80,7 @@ Body:
 $RequestBody
 "@
 
-            if ($pscmdlet.ShouldProcess($Message, $CommonAreaId, "Adding calling plan $LicenseType")) {
+            if ($pscmdlet.ShouldProcess($Message, $ZoomCommonAreaInfo.display_name, "Adding calling plan: $LicenseType")) {
                 $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $requestBody -Method POST
         
                 if (-not $PassThru) {

--- a/PSZoom/Public/Phone/CommonPhone/Add-ZoomPhoneCommonAreaNumber.ps1
+++ b/PSZoom/Public/Phone/CommonPhone/Add-ZoomPhoneCommonAreaNumber.ps1
@@ -53,6 +53,7 @@ function Add-ZoomPhoneCommonAreaNumber {
             }
 
             $NumberInfo = Get-ZoomPhoneNumber -ErrorAction Stop | Where-object Number -eq $number 
+            $ZoomCommonAreaInfo = Get-ZoomPhoneCommonArea -CommonAreaId $CommonArea -ErrorAction Stop
 
             if (-not ($NumberInfo)) {
                 Throw "Provided number was not found in the accounts's phone number list"
@@ -94,7 +95,7 @@ $RequestBody
 "@
 
 
-        if ($pscmdlet.ShouldProcess($Message, $CommonArea, "Adding $Number")) {
+        if ($pscmdlet.ShouldProcess($Message, $ZoomCommonAreaInfo.display_name, "Adding $ChosenNumber")) {
                 $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $requestBody -Method POST
         
                 if (-not $PassThru) {

--- a/PSZoom/Public/Phone/CommonPhone/Remove-ZoomPhoneCommonAreaCallingPlan.ps1
+++ b/PSZoom/Public/Phone/CommonPhone/Remove-ZoomPhoneCommonAreaCallingPlan.ps1
@@ -75,6 +75,7 @@ function Remove-ZoomPhoneCommonAreaCallingPlan {
             "SinglePlan" {
                 Foreach($CommonArea in $CommonAreaId){           
                     $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/common_areas/$CommonArea/calling_plans/$LicenseType"
+                    $ZoomCommonAreaInfo = Get-ZoomPhoneCommonArea -CommonAreaId $CommonArea -ErrorAction Stop
 $Message = 
 @"
 
@@ -84,7 +85,7 @@ Body:
 $RequestBody
 "@
 
-                    if ($pscmdlet.ShouldProcess($Message, $CommonArea, "Remove calling plan $LicenseType")) {
+                    if ($pscmdlet.ShouldProcess($Message, $ZoomCommonAreaInfo.display_name, "Remove calling plan $LicenseType")) {
                         $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method Delete
                 
                         if (-not $PassThru) {
@@ -120,7 +121,7 @@ Body:
 $RequestBody
 "@
 
-                            if ($pscmdlet.ShouldProcess($Message, $CommonArea, "Remove calling plan $CurrentLicense")) {
+                            if ($pscmdlet.ShouldProcess($Message, $CommonArea, "Remove calling plan: $CurrentLicense")) {
                                 $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method Delete
 
                                 if (-not $PassThru) {

--- a/PSZoom/Public/Phone/CommonPhone/Remove-ZoomPhoneCommonAreaNumber.ps1
+++ b/PSZoom/Public/Phone/CommonPhone/Remove-ZoomPhoneCommonAreaNumber.ps1
@@ -108,7 +108,7 @@ Body:
 $RequestBody
 "@
 
-                if ($pscmdlet.ShouldProcess($Message, $_, "Remove $NumberTBR")) {
+                if ($pscmdlet.ShouldProcess($Message, $ZoomEntityInfo.display_name, "Remove $($NumberTBR.number)")) {
                     $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method DELETE
             
                     if (-not $PassThru) {

--- a/PSZoom/Public/Phone/DeskPhone/Get-ZoomPhoneDevice.ps1
+++ b/PSZoom/Public/Phone/DeskPhone/Get-ZoomPhoneDevice.ps1
@@ -6,11 +6,18 @@ List all the desk phone devices that are configured with Zoom Phone on an accoun
 .DESCRIPTION
 List all the desk phone devices that are configured with Zoom Phone on an account.
 
-.PARAMETER UserId
+.PARAMETER DeviceId
 Unique Identifier of the device.
 
 .PARAMETER SiteId
 Unique Identifier of the site. This can be found in the ListPhoneSites API.
+
+.PARAMETER DeviceStatus
+Whether the device is assigned or not.
+
+.PARAMETER AssigneeType
+The type of the assignee. It's available if type = assigned.
+Allowed: user ┃ commonArea
 
 .PARAMETER DeviceType
 The manufacturer name.
@@ -39,7 +46,7 @@ Get-ZoomPhoneDevice -DeviceId ######
 
 .EXAMPLE
 Return devices of a specific manufacture for a specific site.
-Get-ZoomPhoneDevice -SiteId ###### -DeviceType poly
+Get-ZoomPhoneDevice -SiteId ###### -DeviceType "poly" -DeviceStatus "assigned"
 
 #>
 
@@ -61,7 +68,8 @@ function Get-ZoomPhoneDevice {
         [string]$DeviceId,
 
         [parameter(
-            ParameterSetName="SpecificQuery"
+            ParameterSetName="SpecificQuery",
+            Mandatory = $true
         )]
         [ValidateSet("assigned","unassigned")]
         [string]$DeviceStatus,
@@ -76,6 +84,17 @@ function Get-ZoomPhoneDevice {
             'site_id'
         )]
         [string]$SiteId,
+
+        [Parameter(
+            ParameterSetName="SpecificQuery"
+        )]
+        [Alias(
+            'assignee_type'
+        )]
+        [ValidateSet(
+            "user","commonArea"
+        )]
+        [string]$AssigneeType,
 
         [Parameter(
             ParameterSetName="SpecificQuery"
@@ -164,6 +183,14 @@ function Get-ZoomPhoneDevice {
                 }
                 if ($PSBoundParameters.ContainsKey('SiteId')) {
                     $QueryStatements.Add("site_id", $SiteId)
+                }
+                if ($PSBoundParameters.ContainsKey('AssigneeType')) {
+                    if ($AssigneeType -eq "user") {
+                        $AssigneeType = "user"
+                    }elseif ($AssigneeType -eq "commonArea") {
+                        $AssigneeType = "commonArea"
+                    }
+                    $QueryStatements.Add("assignee_type", $AssigneeType)
                 }
                 $AggregatedResponse += Get-ZoomPaginatedData -URI $baseURI -PageSize 100 -AdditionalQueryStatements $QueryStatements
 

--- a/PSZoom/Public/Phone/DeskPhone/Remove-ZoomPhoneDeviceAssignee.ps1
+++ b/PSZoom/Public/Phone/DeskPhone/Remove-ZoomPhoneDeviceAssignee.ps1
@@ -11,7 +11,7 @@ Extension ID of the assignee (user or common area)
 Common Area Extension ID is the same as the Common Area ID
 
 .PARAMETER UnassignAllEntities
-Unique number used to locate device.
+Unassign all attached entities.
 
 .PARAMETER PassThru
 When switched the command will pass the DeviceId back.

--- a/PSZoom/Public/Phone/UserPhone/Add-ZoomPhoneUserCallingPlan.ps1
+++ b/PSZoom/Public/Phone/UserPhone/Add-ZoomPhoneUserCallingPlan.ps1
@@ -48,7 +48,7 @@ function Add-ZoomPhoneUserCallingPlan {
     
     process {
         foreach ($user in $UserId) {
-            
+
             if (-not (Get-ZoomUserSettings -UserId $user | Select-Object -ExpandProperty "feature" | Select-Object -ExpandProperty "zoom_phone")) {
                 Update-ZoomUserSettings -UserId $user -ZoomPhone $True
             }
@@ -70,6 +70,8 @@ function Add-ZoomPhoneUserCallingPlan {
 
             $RequestBody.Add("calling_plans", $ChosenLicense)
 
+            $ZoomUserInfo = Get-ZoomPhoneUser -UserId $user -ErrorAction Stop
+
             $RequestBody = $RequestBody | ConvertTo-Json
             $Message = 
 @"
@@ -80,7 +82,7 @@ Body:
 $RequestBody
 "@
 
-        if ($pscmdlet.ShouldProcess($Message, $UserId, "Update calling plan")) {
+        if ($pscmdlet.ShouldProcess($Message, $ZoomUserInfo.email, "Update calling plan: $LicenseType")) {
                 $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $requestBody -Method POST
         
                 if (-not $PassThru) {

--- a/PSZoom/Public/Phone/UserPhone/Add-ZoomPhoneUserNumber.ps1
+++ b/PSZoom/Public/Phone/UserPhone/Add-ZoomPhoneUserNumber.ps1
@@ -54,6 +54,7 @@ function Add-ZoomPhoneUserNumber {
                 $number = "{0}$number" -f '+'
             }
 
+            $ZoomUserInfo = Get-ZoomPhoneUser -UserId $user -ErrorAction Stop
             $NumberInfo = Get-ZoomPhoneNumber -ErrorAction Stop | Where-object Number -eq $number 
 
             if (-not ($NumberInfo)) {
@@ -92,7 +93,7 @@ Body:
 $RequestBody
 "@
 
-        if ($pscmdlet.ShouldProcess($Message, $UserId, "Adding $Number")) {
+        if ($pscmdlet.ShouldProcess($Message, $ZoomUserInfo.email, "Adding $($NumberInfo.number)")) {
                 $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $requestBody -Method POST
         
                 if (-not $PassThru) {

--- a/PSZoom/Public/Phone/UserPhone/Remove-ZoomPhoneUserCallingPlan.ps1
+++ b/PSZoom/Public/Phone/UserPhone/Remove-ZoomPhoneUserCallingPlan.ps1
@@ -37,7 +37,8 @@ function Remove-ZoomPhoneUserCallingPlan {
 
     process {
         foreach ($user in $UserId) {
-            $CurrentLicense = Get-ZoomPhoneUser -UserId $user | Select-Object -ExpandProperty "calling_plans" | Select-Object -ExpandProperty "type"
+            $ZoomUserInfo = Get-ZoomPhoneUser -UserId $user -ErrorAction Stop
+            $CurrentLicense = $ZoomUserInfo | Select-Object -ExpandProperty "calling_plans" | Select-Object -ExpandProperty "type"
             $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/users/$user/calling_plans/$CurrentLicense"
             $Message = 
 @"
@@ -48,7 +49,7 @@ Body:
 $RequestBody
 "@
 
-            if ($pscmdlet.ShouldProcess($Message, $User, "Remove calling plan")) {
+            if ($pscmdlet.ShouldProcess($Message, $ZoomUserInfo.email, "Remove calling plan: $CurrentLicense")) {
                 $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method Delete
         
                 if (-not $PassThru) {

--- a/PSZoom/Public/Phone/UserPhone/Remove-ZoomPhoneUserNumber.ps1
+++ b/PSZoom/Public/Phone/UserPhone/Remove-ZoomPhoneUserNumber.ps1
@@ -103,7 +103,7 @@ Body:
 $RequestBody
 "@
 
-            if ($pscmdlet.ShouldProcess($Message, $User, "Remove $Number")) {
+            if ($pscmdlet.ShouldProcess($Message, $ZoomUserInfo.email, "Remove $($_.number)")) {
                     $response = Invoke-ZoomRestMethod -Uri $request.Uri -Method DELETE
             
                     if (-not $PassThru) {

--- a/PSZoom/Public/Phone/UserPhone/Update-ZoomPhoneUserCallingPlan.ps1
+++ b/PSZoom/Public/Phone/UserPhone/Update-ZoomPhoneUserCallingPlan.ps1
@@ -52,7 +52,8 @@ function Update-ZoomPhoneUserCallingPlan {
     process {
         foreach ($user in $UserId) {
 
-            $CurrentLicense = Get-ZoomPhoneUser -UserId $user | Select-Object -ExpandProperty "calling_plans" | Select-Object -ExpandProperty "type"
+            $ZoomUserInfo = Get-ZoomPhoneUser -UserId $user -ErrorAction Stop
+            $CurrentLicense = $ZoomUserInfo | Select-Object -ExpandProperty "calling_plans" | Select-Object -ExpandProperty "type"
 
             $Request = [System.UriBuilder]"https://api.$ZoomURI/v2/phone/users/$user/calling_plans"
             $RequestBody = @{ }
@@ -77,7 +78,7 @@ Body:
 $RequestBody
 "@
 
-            if ($pscmdlet.ShouldProcess($Message, $User, "Update calling plan")) {
+            if ($pscmdlet.ShouldProcess($Message, $ZoomUserInfo.email, "Update calling plan: $LicenseType")) {
                 $response = Invoke-ZoomRestMethod -Uri $request.Uri -Body $requestBody -Method PUT
         
                 if (-not $PassThru) {


### PR DESCRIPTION
Fixed some -confirm messages with friendly names versus unreadable UserID.

```powershell
Remove-ZoomPhoneUserCallingPlan -UserId askywakler@thejedi.com -Confirm
```
\
Fixed some missing arguments from a few Zoomphone cmdlets